### PR TITLE
feat(scheduler): distinguish deliberate skips from real failures

### DIFF
--- a/src/mycoach/api/routes/activities.py
+++ b/src/mycoach/api/routes/activities.py
@@ -6,6 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from mycoach.coaching.engine import CoachingEngine
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.database import get_db
 from mycoach.models.activity import Activity, GymWorkoutDetail
 from mycoach.models.coaching import CoachingInsight
@@ -129,7 +130,7 @@ async def analyze_activity(
         insight = await engine.generate_post_workout_analysis(
             session, DEFAULT_USER_ID, activity_id, force=force
         )
-    except ValueError as e:
+    except (PipelineSkip, ValueError) as e:
         raise HTTPException(status_code=409, detail=str(e)) from None
     except RuntimeError as e:
         raise HTTPException(status_code=502, detail=str(e)) from None

--- a/src/mycoach/api/routes/coaching.py
+++ b/src/mycoach/api/routes/coaching.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from mycoach.coaching.engine import CoachingEngine
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.database import get_db
 from mycoach.models.coaching import CoachingInsight
 from mycoach.schemas.coaching import CoachingInsightRead
@@ -52,7 +53,7 @@ async def generate_today_briefing(
     engine = CoachingEngine()
     try:
         insight = await engine.generate_daily_briefing(session, USER_ID, force=force)
-    except ValueError as e:
+    except (PipelineSkip, ValueError) as e:
         raise HTTPException(status_code=409, detail=str(e)) from None
     except RuntimeError as e:
         raise HTTPException(status_code=502, detail=str(e)) from None
@@ -107,7 +108,7 @@ async def generate_weekly_recap(
         insight = await engine.generate_weekly_recap(
             session, USER_ID, week_start, force=force
         )
-    except ValueError as e:
+    except (PipelineSkip, ValueError) as e:
         raise HTTPException(status_code=409, detail=str(e)) from None
     except RuntimeError as e:
         raise HTTPException(status_code=502, detail=str(e)) from None

--- a/src/mycoach/api/routes/plans.py
+++ b/src/mycoach/api/routes/plans.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from mycoach.coaching.engine import CoachingEngine
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.database import get_db
 from mycoach.models.plan import PlannedSession, WeeklyPlan
 from mycoach.schemas.plan import (
@@ -50,7 +51,7 @@ async def generate_plan(
     engine = CoachingEngine()
     try:
         plan = await engine.generate_weekly_plan(session, USER_ID, week_start, force=force)
-    except ValueError as e:
+    except (PipelineSkip, ValueError) as e:
         raise HTTPException(status_code=409, detail=str(e)) from None
     except RuntimeError as e:
         raise HTTPException(status_code=502, detail=str(e)) from None

--- a/src/mycoach/coaching/engine.py
+++ b/src/mycoach/coaching/engine.py
@@ -29,6 +29,7 @@ from mycoach.coaching.context import (
     get_today_planned_sessions,
     link_activity_to_planned_session,
 )
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.coaching.llm_client import LLMClient, LLMResponse, get_llm_client
 from mycoach.coaching.prompt_builder import (
     build_cardio_plan_prompt,
@@ -95,7 +96,7 @@ class CoachingEngine:
                     )
                 )
             else:
-                raise ValueError(f"Daily briefing already exists for {today}")
+                raise PipelineSkip(f"Daily briefing already exists for {today}")
 
         # Gather context
         health_today = await get_today_health(session, user_id, today)
@@ -264,12 +265,12 @@ class CoachingEngine:
                 await session.delete(existing_plan)
                 await session.flush()
             else:
-                raise ValueError(f"Active plan already exists for week of {week_start}")
+                raise PipelineSkip(f"Active plan already exists for week of {week_start}")
 
         # 1. Gather shared context
         availability = await get_availability_for_week(session, user_id, week_start)
         if not availability:
-            raise ValueError(f"No availability slots set for week of {week_start}")
+            raise PipelineSkip(f"No availability slots set for week of {week_start}")
         logger.info(
             "Availability for week %s: %s",
             week_start,
@@ -566,7 +567,7 @@ class CoachingEngine:
                     )
                 )
             else:
-                raise ValueError(
+                raise PipelineSkip(
                     f"Post-workout analysis already exists for activity {activity_id}"
                 )
 
@@ -703,7 +704,7 @@ class CoachingEngine:
                     )
                 )
             else:
-                raise ValueError(f"Weekly recap already exists for week of {week_start}")
+                raise PipelineSkip(f"Weekly recap already exists for week of {week_start}")
 
         # Gather context
         plan_adherence = await get_plan_adherence_for_week(session, user_id, week_start)

--- a/src/mycoach/coaching/exceptions.py
+++ b/src/mycoach/coaching/exceptions.py
@@ -1,0 +1,13 @@
+"""Exceptions for the coaching pipeline."""
+
+
+class PipelineSkip(Exception):  # noqa: N818 - a skip is deliberately not an error
+    """Raised when a coaching pipeline step has nothing to do.
+
+    A skip is a deliberate no-op — an insight already exists for the period,
+    there are no new activities to analyse, or no availability is configured.
+    Every *other* exception raised out of a pipeline step means a real failure.
+    Keeping skips in their own type stops genuine corruption (e.g. a malformed
+    LLM response, whose ``json.JSONDecodeError`` is a ``ValueError`` subtype)
+    from being mistaken for a routine skip.
+    """

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -13,6 +13,7 @@ from datetime import date, datetime, timedelta
 from sqlalchemy import select
 
 from mycoach.coaching.engine import CoachingEngine
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.config import get_settings
 from mycoach.database import async_session
 from mycoach.email.sender import (
@@ -44,6 +45,21 @@ def _run_async(coro):  # type: ignore[no-untyped-def]
         loop.close()
 
 
+def _run_job(label: str, coro) -> None:  # type: ignore[no-untyped-def]
+    """Run a pipeline coroutine, translating its outcome into a log line.
+
+    A ``PipelineSkip`` is a deliberate no-op and logged at info level. Every
+    other exception is a real failure and logged at error level. This is the
+    skip-versus-failure boundary the rest of the pipeline keys on.
+    """
+    try:
+        _run_async(coro)
+    except PipelineSkip as e:
+        logger.info("Scheduler: %s skipped — %s", label, e)
+    except Exception:
+        logger.exception("Scheduler: %s failed", label)
+
+
 async def _get_user_email_pref(pref_field: str) -> bool:
     """Check if user has a specific email preference enabled."""
     settings = get_settings()
@@ -63,64 +79,51 @@ def job_garmin_sync() -> None:
     Fetches the last 2 days of data to handle timezone edge cases and overnight sync.
     """
     logger.info("Scheduler: starting Garmin sync")
-    _run_async(_garmin_sync())
+    _run_job("Garmin sync", _garmin_sync())
 
 
 async def _garmin_sync() -> None:
     source = GarminSource()
-    try:
-        if not await source.authenticate():
-            logger.error("Scheduler: Garmin authentication failed")
-            return
-    except Exception:
-        logger.exception("Scheduler: Garmin authentication error")
-        return
+    if not await source.authenticate():
+        raise RuntimeError("Garmin authentication failed")
 
     async with async_session() as session:
-        try:
-            since = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
-            since = since - timedelta(days=2)
-            result = await source.fetch_and_import(session, USER_ID, since=since)
-            merge_result = await merge_garmin_hevy(session, USER_ID)
-            await session.commit()
-            logger.info(
-                "Scheduler: Garmin sync complete — health=%d, activities=%d, merged=%d",
-                result.health_snapshots_created,
-                result.activities_created,
-                merge_result.merged,
-            )
-        except Exception:
-            logger.exception("Scheduler: Garmin sync failed")
+        since = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        since = since - timedelta(days=2)
+        result = await source.fetch_and_import(session, USER_ID, since=since)
+        merge_result = await merge_garmin_hevy(session, USER_ID)
+        await session.commit()
+        logger.info(
+            "Scheduler: Garmin sync complete — health=%d, activities=%d, merged=%d",
+            result.health_snapshots_created,
+            result.activities_created,
+            merge_result.merged,
+        )
 
 
 def job_daily_briefing() -> None:
     """Generate the daily coaching briefing."""
     logger.info("Scheduler: generating daily briefing")
-    _run_async(_daily_briefing())
+    _run_job("daily briefing", _daily_briefing())
 
 
 async def _daily_briefing() -> None:
     engine = CoachingEngine()
     async with async_session() as session:
-        try:
-            insight = await engine.generate_daily_briefing(session, USER_ID)
-            logger.info("Scheduler: daily briefing generated")
+        insight = await engine.generate_daily_briefing(session, USER_ID)
+        logger.info("Scheduler: daily briefing generated")
 
-            if await _get_user_email_pref("email_daily_briefing"):
-                content = json.loads(insight.content)
-                send_daily_briefing(content)
-                logger.info("Scheduler: daily briefing email sent")
-        except ValueError as e:
-            logger.info("Scheduler: daily briefing skipped — %s", e)
-        except Exception:
-            logger.exception("Scheduler: daily briefing failed")
+        if await _get_user_email_pref("email_daily_briefing"):
+            content = json.loads(insight.content)
+            send_daily_briefing(content)
+            logger.info("Scheduler: daily briefing email sent")
 
 
 
 def job_weekly_plan() -> None:
     """Generate the weekly training plan (runs Sunday evening for next week)."""
     logger.info("Scheduler: generating weekly plan")
-    _run_async(_weekly_plan())
+    _run_job("weekly plan", _weekly_plan())
 
 
 async def _weekly_plan() -> None:
@@ -132,44 +135,39 @@ async def _weekly_plan() -> None:
     next_monday = today + timedelta(days=days_until_monday)
 
     async with async_session() as session:
-        try:
-            plan = await engine.generate_weekly_plan(session, USER_ID, next_monday)
-            logger.info("Scheduler: weekly plan generated for %s", next_monday)
+        plan = await engine.generate_weekly_plan(session, USER_ID, next_monday)
+        logger.info("Scheduler: weekly plan generated for %s", next_monday)
 
-            if await _get_user_email_pref("email_weekly_plan"):
-                result = await session.execute(
-                    select(PlannedSession)
-                    .where(PlannedSession.plan_id == plan.id)
-                    .order_by(PlannedSession.day_of_week)
-                )
-                sessions = result.scalars().all()
-                session_dicts = [
-                    {
-                        "day_name": DAY_NAMES[s.day_of_week],
-                        "title": s.title,
-                        "sport": s.sport,
-                        "duration_minutes": s.duration_minutes,
-                        "notes": s.notes,
-                        "details": json.loads(s.details) if s.details else None,
-                    }
-                    for s in sessions
-                ]
-                send_weekly_plan(
-                    summary=plan.summary or "",
-                    sessions=session_dicts,
-                    week_start=str(next_monday),
-                )
-                logger.info("Scheduler: weekly plan email sent")
-        except ValueError as e:
-            logger.info("Scheduler: weekly plan skipped — %s", e)
-        except Exception:
-            logger.exception("Scheduler: weekly plan generation failed")
+        if await _get_user_email_pref("email_weekly_plan"):
+            result = await session.execute(
+                select(PlannedSession)
+                .where(PlannedSession.plan_id == plan.id)
+                .order_by(PlannedSession.day_of_week)
+            )
+            sessions = result.scalars().all()
+            session_dicts = [
+                {
+                    "day_name": DAY_NAMES[s.day_of_week],
+                    "title": s.title,
+                    "sport": s.sport,
+                    "duration_minutes": s.duration_minutes,
+                    "notes": s.notes,
+                    "details": json.loads(s.details) if s.details else None,
+                }
+                for s in sessions
+            ]
+            send_weekly_plan(
+                summary=plan.summary or "",
+                sessions=session_dicts,
+                week_start=str(next_monday),
+            )
+            logger.info("Scheduler: weekly plan email sent")
 
 
 def job_weekly_recap() -> None:
     """Generate the weekly recap (runs Monday morning for the previous week)."""
     logger.info("Scheduler: generating weekly recap")
-    _run_async(_weekly_recap())
+    _run_job("weekly recap", _weekly_recap())
 
 
 async def _weekly_recap() -> None:
@@ -178,18 +176,13 @@ async def _weekly_recap() -> None:
     last_monday = today - timedelta(days=today.weekday() + 7)
 
     async with async_session() as session:
-        try:
-            insight = await engine.generate_weekly_recap(session, USER_ID, last_monday)
-            logger.info("Scheduler: weekly recap generated for week of %s", last_monday)
+        insight = await engine.generate_weekly_recap(session, USER_ID, last_monday)
+        logger.info("Scheduler: weekly recap generated for week of %s", last_monday)
 
-            if await _get_user_email_pref("email_weekly_recap"):
-                content = json.loads(insight.content)
-                send_weekly_recap(content, week_start=str(last_monday))
-                logger.info("Scheduler: weekly recap email sent")
-        except ValueError as e:
-            logger.info("Scheduler: weekly recap skipped — %s", e)
-        except Exception:
-            logger.exception("Scheduler: weekly recap generation failed")
+        if await _get_user_email_pref("email_weekly_recap"):
+            content = json.loads(insight.content)
+            send_weekly_recap(content, week_start=str(last_monday))
+            logger.info("Scheduler: weekly recap email sent")
 
 
 def job_post_workout_analysis() -> None:
@@ -199,7 +192,7 @@ def job_post_workout_analysis() -> None:
     an existing CoachingInsight, generates analysis for each, and sends email.
     """
     logger.info("Scheduler: starting post-workout analysis scan")
-    _run_async(_post_workout_analysis())
+    _run_job("post-workout analysis", _post_workout_analysis())
 
 
 async def _post_workout_analysis() -> None:
@@ -230,13 +223,14 @@ async def _post_workout_analysis() -> None:
         activities = list(result.scalars().all())
 
         if not activities:
-            logger.info("Scheduler: no new activities to analyze")
-            return
+            raise PipelineSkip("no new activities to analyse")
 
         logger.info("Scheduler: found %d activities to analyze", len(activities))
         send_email = await _get_user_email_pref("email_post_workout")
 
         for activity in activities:
+            # Per-activity resilience: one activity's skip or failure must not
+            # abort the batch. A whole-batch skip (no activities) is raised above.
             try:
                 insight = await engine.generate_post_workout_analysis(
                     session, USER_ID, activity.id
@@ -253,7 +247,7 @@ async def _post_workout_analysis() -> None:
                     logger.info(
                         "Scheduler: post-workout email sent for activity %d", activity.id
                     )
-            except ValueError as e:
+            except PipelineSkip as e:
                 logger.info(
                     "Scheduler: post-workout analysis skipped for activity %d — %s",
                     activity.id,

--- a/tests/test_coaching/test_engine.py
+++ b/tests/test_coaching/test_engine.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy import select
 
 from mycoach.coaching.engine import CoachingEngine
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.coaching.llm_client import LLMResponse
 from mycoach.models.health import DailyHealthSnapshot
 from mycoach.models.prompt_log import PromptLog
@@ -107,7 +108,7 @@ class TestGenerateDailyBriefing:
             engine = CoachingEngine(llm_client=mock_llm)
             await engine.generate_daily_briefing(session, user_id, today)
 
-            with pytest.raises(ValueError, match="already exists"):
+            with pytest.raises(PipelineSkip, match="already exists"):
                 await engine.generate_daily_briefing(session, user_id, today)
 
     async def test_llm_failure_raises_and_logs(self) -> None:

--- a/tests/test_plans/test_engine.py
+++ b/tests/test_plans/test_engine.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy import select
 
 from mycoach.coaching.engine import CoachingEngine
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.coaching.llm_client import LLMResponse
 from mycoach.models.availability import WeeklyAvailability
 from mycoach.models.plan import PlannedSession
@@ -272,7 +273,7 @@ class TestGenerateWeeklyPlan:
             engine = CoachingEngine(llm_client=mock_llm)
             await engine.generate_weekly_plan(session, user_id, week_start)
 
-            with pytest.raises(ValueError, match="already exists"):
+            with pytest.raises(PipelineSkip, match="already exists"):
                 await engine.generate_weekly_plan(session, user_id, week_start)
 
     async def test_no_availability_raises(self) -> None:
@@ -285,7 +286,7 @@ class TestGenerateWeeklyPlan:
             mock_llm = _mock_llm_client()
             engine = CoachingEngine(llm_client=mock_llm)
 
-            with pytest.raises(ValueError, match="No availability"):
+            with pytest.raises(PipelineSkip, match="No availability"):
                 await engine.generate_weekly_plan(session, user.id, date(2024, 6, 10))
 
     async def test_non_monday_raises(self) -> None:

--- a/tests/test_post_workout/test_engine.py
+++ b/tests/test_post_workout/test_engine.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy import select
 
 from mycoach.coaching.engine import CoachingEngine
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.coaching.llm_client import LLMResponse
 from mycoach.models.activity import Activity, GymWorkoutDetail
 from mycoach.models.plan import PlannedSession, WeeklyPlan
@@ -123,7 +124,7 @@ class TestGeneratePostWorkoutAnalysis:
             engine = CoachingEngine(llm_client=mock_llm)
             await engine.generate_post_workout_analysis(session, user_id, activity_id)
 
-            with pytest.raises(ValueError, match="already exists"):
+            with pytest.raises(PipelineSkip, match="already exists"):
                 await engine.generate_post_workout_analysis(session, user_id, activity_id)
 
     async def test_activity_not_found_raises(self) -> None:

--- a/tests/test_scheduler/test_jobs.py
+++ b/tests/test_scheduler/test_jobs.py
@@ -1,16 +1,22 @@
 """Tests for scheduler job functions."""
 
+import logging
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.scheduler.jobs import (
     _daily_briefing,
     _garmin_sync,
     _post_workout_analysis,
     _weekly_plan,
     _weekly_recap,
+    job_daily_briefing,
+    job_garmin_sync,
+    job_weekly_plan,
+    job_weekly_recap,
 )
 
 
@@ -53,17 +59,37 @@ async def test_garmin_sync_success(mock_session: AsyncMock) -> None:
     mock_session.commit.assert_awaited_once()
 
 
-async def test_garmin_sync_auth_failure(mock_session: AsyncMock) -> None:
-    """Garmin sync should log and return on auth failure."""
+async def test_garmin_sync_auth_failure_raises(mock_session: AsyncMock) -> None:
+    """Garmin auth failure should raise rather than return silently."""
     mock_source = MagicMock()
     mock_source.authenticate = AsyncMock(return_value=False)
     mock_source.fetch_and_import = AsyncMock()
 
-    with patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source):
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source),
+        pytest.raises(RuntimeError, match="authentication failed"),
+    ):
         await _garmin_sync()
 
     mock_source.authenticate.assert_awaited_once()
     mock_source.fetch_and_import.assert_not_awaited()
+
+
+def test_garmin_sync_job_logs_auth_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """The Garmin job wrapper surfaces an auth failure at error level, not silently."""
+    mock_source = MagicMock()
+    mock_source.authenticate = AsyncMock(return_value=False)
+
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source),
+        caplog.at_level(logging.INFO),
+    ):
+        job_garmin_sync()  # must not raise
+
+    assert any(
+        r.levelno == logging.ERROR and "Garmin sync failed" in r.message
+        for r in caplog.records
+    )
 
 
 async def test_daily_briefing_success(mock_session: AsyncMock, mock_engine: MagicMock) -> None:
@@ -77,20 +103,69 @@ async def test_daily_briefing_success(mock_session: AsyncMock, mock_engine: Magi
     mock_engine.generate_daily_briefing.assert_awaited_once()
 
 
-async def test_daily_briefing_skips_duplicate(
+async def test_daily_briefing_raises_skip_on_duplicate(
     mock_session: AsyncMock, mock_engine: MagicMock
 ) -> None:
-    """Daily briefing should skip gracefully when one already exists."""
+    """The daily briefing coroutine propagates a PipelineSkip when one exists."""
     mock_engine.generate_daily_briefing = AsyncMock(
-        side_effect=ValueError("Daily briefing already exists")
+        side_effect=PipelineSkip("Daily briefing already exists")
     )
 
     with (
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        pytest.raises(PipelineSkip),
     ):
-        # Should not raise
         await _daily_briefing()
+
+
+def test_daily_briefing_job_logs_skip(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A skip is logged at info level and swallowed by the job wrapper."""
+    mock_engine.generate_daily_briefing = AsyncMock(
+        side_effect=PipelineSkip("Daily briefing already exists")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        caplog.at_level(logging.INFO),
+    ):
+        job_daily_briefing()  # must not raise
+
+    skip_logs = [
+        r for r in caplog.records if "daily briefing skipped" in r.message
+    ]
+    assert skip_logs and all(r.levelno == logging.INFO for r in skip_logs)
+    assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+
+
+def test_daily_briefing_job_logs_malformed_response_as_failure(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A malformed stored response is a failure (error), not a routine skip.
+
+    The insight content fails to JSON-decode when building the email; that
+    JSONDecodeError is a ValueError subtype and must not be swallowed as a skip.
+    """
+    mock_insight = MagicMock()
+    mock_insight.content = "not valid json{"
+    mock_engine.generate_daily_briefing = AsyncMock(return_value=mock_insight)
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        caplog.at_level(logging.INFO),
+    ):
+        job_daily_briefing()  # must not raise
+
+    assert any(
+        r.levelno == logging.ERROR and "daily briefing failed" in r.message
+        for r in caplog.records
+    )
+    assert not any("skipped" in r.message for r in caplog.records)
 
 
 
@@ -131,6 +206,73 @@ async def test_weekly_plan_from_sunday(mock_session: AsyncMock, mock_engine: Mag
     mock_engine.generate_weekly_plan.assert_awaited_once_with(mock_session, 1, expected_monday)
 
 
+async def test_weekly_plan_raises_skip_on_duplicate(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """The weekly plan coroutine propagates a PipelineSkip when one exists."""
+    mock_engine.generate_weekly_plan = AsyncMock(
+        side_effect=PipelineSkip("Active plan already exists")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.date") as mock_date,
+    ):
+        mock_date.today.return_value = date(2025, 1, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        with pytest.raises(PipelineSkip):
+            await _weekly_plan()
+
+
+def test_weekly_plan_job_logs_skip(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A skip is logged at info level and swallowed by the job wrapper."""
+    mock_engine.generate_weekly_plan = AsyncMock(
+        side_effect=PipelineSkip("Active plan already exists")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.date") as mock_date,
+        caplog.at_level(logging.INFO),
+    ):
+        mock_date.today.return_value = date(2025, 1, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        job_weekly_plan()  # must not raise
+
+    skip_logs = [r for r in caplog.records if "weekly plan skipped" in r.message]
+    assert skip_logs and all(r.levelno == logging.INFO for r in skip_logs)
+    assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+
+
+def test_weekly_plan_job_logs_failure(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-skip exception is logged at error level by the job wrapper."""
+    mock_engine.generate_weekly_plan = AsyncMock(
+        side_effect=RuntimeError("Failed to generate weekly plan: bad JSON")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.date") as mock_date,
+        caplog.at_level(logging.INFO),
+    ):
+        mock_date.today.return_value = date(2025, 1, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        job_weekly_plan()  # must not raise
+
+    assert any(
+        r.levelno == logging.ERROR and "weekly plan failed" in r.message
+        for r in caplog.records
+    )
+    assert not any("skipped" in r.message for r in caplog.records)
+
+
 async def test_weekly_recap_calculates_last_monday(
     mock_session: AsyncMock, mock_engine: MagicMock
 ) -> None:
@@ -152,12 +294,12 @@ async def test_weekly_recap_calculates_last_monday(
     )
 
 
-async def test_weekly_recap_skips_duplicate(
+async def test_weekly_recap_raises_skip_on_duplicate(
     mock_session: AsyncMock, mock_engine: MagicMock
 ) -> None:
-    """Weekly recap should skip gracefully when one already exists."""
+    """The weekly recap coroutine propagates a PipelineSkip when one exists."""
     mock_engine.generate_weekly_recap = AsyncMock(
-        side_effect=ValueError("Weekly recap already exists")
+        side_effect=PipelineSkip("Weekly recap already exists")
     )
 
     with (
@@ -167,8 +309,33 @@ async def test_weekly_recap_skips_duplicate(
     ):
         mock_date.today.return_value = date(2025, 1, 20)
         mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
-        # Should not raise
-        await _weekly_recap()
+        with pytest.raises(PipelineSkip):
+            await _weekly_recap()
+
+
+def test_weekly_recap_job_logs_failure(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-skip exception is logged at error level by the job wrapper."""
+    mock_engine.generate_weekly_recap = AsyncMock(
+        side_effect=RuntimeError("Failed to generate weekly recap: bad JSON")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.date") as mock_date,
+        caplog.at_level(logging.INFO),
+    ):
+        mock_date.today.return_value = date(2025, 1, 20)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        job_weekly_recap()  # must not raise
+
+    assert any(
+        r.levelno == logging.ERROR and "weekly recap failed" in r.message
+        for r in caplog.records
+    )
+    assert not any("skipped" in r.message for r in caplog.records)
 
 
 async def test_post_workout_analysis_processes_new_activities(
@@ -197,10 +364,10 @@ async def test_post_workout_analysis_processes_new_activities(
     mock_engine.generate_post_workout_analysis.assert_any_await(mock_session, 1, 11)
 
 
-async def test_post_workout_analysis_no_activities(
+async def test_post_workout_analysis_no_activities_raises_skip(
     mock_session: AsyncMock, mock_engine: MagicMock,
 ) -> None:
-    """Post-workout job should skip when no new activities exist."""
+    """Post-workout job raises PipelineSkip when there are no new activities."""
     mock_engine.generate_post_workout_analysis = AsyncMock()
 
     mock_result = MagicMock()
@@ -210,23 +377,28 @@ async def test_post_workout_analysis_no_activities(
     with (
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        pytest.raises(PipelineSkip, match="no new activities"),
     ):
         await _post_workout_analysis()
 
     mock_engine.generate_post_workout_analysis.assert_not_awaited()
 
 
-async def test_post_workout_analysis_skips_existing(
+async def test_post_workout_analysis_skips_existing_per_activity(
     mock_session: AsyncMock, mock_engine: MagicMock,
 ) -> None:
-    """Post-workout job should skip activities that already have analysis (ValueError)."""
-    mock_activity = MagicMock(id=10, title="Morning Swim")
+    """A per-activity PipelineSkip is caught in the loop so the batch continues."""
+    mock_activity_1 = MagicMock(id=10, title="Morning Swim")
+    mock_activity_2 = MagicMock(id=11, title="Gym Session")
     mock_engine.generate_post_workout_analysis = AsyncMock(
-        side_effect=ValueError("Post-workout analysis already exists for activity 10")
+        side_effect=[
+            PipelineSkip("Post-workout analysis already exists for activity 10"),
+            MagicMock(content='{"performance_summary": "ok"}'),
+        ]
     )
 
     mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = [mock_activity]
+    mock_result.scalars.return_value.all.return_value = [mock_activity_1, mock_activity_2]
     mock_session.execute = AsyncMock(return_value=mock_result)
 
     with (
@@ -234,8 +406,42 @@ async def test_post_workout_analysis_skips_existing(
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
     ):
-        # Should not raise
+        # A skip on activity 10 must not stop activity 11 being analysed.
         await _post_workout_analysis()
+
+    assert mock_engine.generate_post_workout_analysis.await_count == 2
+
+
+async def test_post_workout_analysis_failure_does_not_abort_batch(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A per-activity failure is logged at error level and the batch continues."""
+    mock_activity_1 = MagicMock(id=10, title="Morning Swim")
+    mock_activity_2 = MagicMock(id=11, title="Gym Session")
+    mock_engine.generate_post_workout_analysis = AsyncMock(
+        side_effect=[
+            RuntimeError("Failed to generate post-workout analysis: bad JSON"),
+            MagicMock(content='{"performance_summary": "ok"}'),
+        ]
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_activity_1, mock_activity_2]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        caplog.at_level(logging.INFO),
+    ):
+        await _post_workout_analysis()
+
+    assert mock_engine.generate_post_workout_analysis.await_count == 2
+    assert any(
+        r.levelno == logging.ERROR and "post-workout analysis failed for activity 10" in r.message
+        for r in caplog.records
+    )
 
 
 async def test_post_workout_analysis_sends_email(

--- a/tests/test_weekly_recap/test_engine.py
+++ b/tests/test_weekly_recap/test_engine.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy import select
 
 from mycoach.coaching.engine import CoachingEngine
+from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.coaching.llm_client import LLMResponse
 from mycoach.models.activity import Activity
 from mycoach.models.plan import PlannedSession, WeeklyPlan
@@ -105,7 +106,7 @@ class TestGenerateWeeklyRecap:
             engine = CoachingEngine(llm_client=mock_llm)
             await engine.generate_weekly_recap(session, user_id, week_start)
 
-            with pytest.raises(ValueError, match="already exists"):
+            with pytest.raises(PipelineSkip, match="already exists"):
                 await engine.generate_weekly_recap(session, user_id, week_start)
 
     async def test_non_monday_raises(self) -> None:


### PR DESCRIPTION
Introduce a dedicated PipelineSkip exception so a skip is something the pipeline states on purpose, and every other exception means failure. This is the semantic boundary the run-recording work will key on for alerting.

- Add PipelineSkip (coaching/exceptions.py); the engine raises it for genuine no-ops (insight already exists, no availability) instead of the generic ValueError that JSON decode errors are a subtype of.
- Route all five scheduler jobs through a shared _run_job helper: a PipelineSkip logs at info, every other exception logs at error level. A malformed stored response now surfaces as a failure, not a skip, because its json.loads no longer sits under skip handling.
- Post-workout: raise PipelineSkip for an empty batch; keep per-activity resilience so one activity's skip/failure doesn't abort the batch.
- Garmin auth failure raises RuntimeError instead of returning silently.
- API routes catch (PipelineSkip, ValueError) so "already exists" still returns 409 now that PipelineSkip no longer subclasses ValueError.
- Cover the skip-versus-failure boundary for each job and update engine tests to expect PipelineSkip.

Closes #6