### PR TITLE
feat(scheduler): record daily-briefing run outcomes durably

### DIFF
--- a/alembic/versions/e5f6a7b8c9d0_add_job_runs_table.py
+++ b/alembic/versions/e5f6a7b8c9d0_add_job_runs_table.py
@@ -1,0 +1,37 @@
+"""add job_runs table
+
+Revision ID: e5f6a7b8c9d0
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5f6a7b8c9d0'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'job_runs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('job_name', sa.String(length=100), nullable=False),
+        sa.Column('started_at', sa.DateTime(), nullable=False),
+        sa.Column('duration_ms', sa.Integer(), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('error', sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('job_runs')

--- a/src/mycoach/logging_config.py
+++ b/src/mycoach/logging_config.py
@@ -22,8 +22,17 @@ class JSONFormatter(logging.Formatter):
         }
         if record.exc_info and record.exc_info[0] is not None:
             log_entry["exception"] = self.formatException(record.exc_info)
-        # Propagate extra fields attached by callers (e.g. request_id)
-        for key in ("request_id", "method", "path", "status_code", "duration_ms"):
+        # Propagate extra fields attached by callers (e.g. request_id, job run facts)
+        for key in (
+            "request_id",
+            "method",
+            "path",
+            "status_code",
+            "duration_ms",
+            "job_name",
+            "job_status",
+            "job_error",
+        ):
             value = getattr(record, key, None)
             if value is not None:
                 log_entry[key] = value

--- a/src/mycoach/models/__init__.py
+++ b/src/mycoach/models/__init__.py
@@ -3,6 +3,7 @@ from mycoach.models.availability import WeeklyAvailability
 from mycoach.models.coaching import CoachingInsight, MesocycleConfig
 from mycoach.models.data_source import DataSourceConfig
 from mycoach.models.health import DailyHealthSnapshot
+from mycoach.models.job_run import JobRun
 from mycoach.models.plan import PlannedSession, WeeklyPlan
 from mycoach.models.prompt_log import PromptLog
 from mycoach.models.routine import RoutineDay, RoutineExercise, WorkoutRoutine
@@ -15,6 +16,7 @@ __all__ = [
     "DailyHealthSnapshot",
     "DataSourceConfig",
     "GymWorkoutDetail",
+    "JobRun",
     "MesocycleConfig",
     "PlannedSession",
     "PromptLog",

--- a/src/mycoach/models/job_run.py
+++ b/src/mycoach/models/job_run.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from mycoach.database import Base
+
+
+class JobRun(Base):
+    """Durable record of a single scheduled-job execution.
+
+    Append-only, write-only exhaust: nothing in the coaching, source, or
+    scheduler logic ever reads it. Idempotency comes from checking for existing
+    insights, never from querying run history.
+    """
+
+    __tablename__ = "job_runs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    job_name: Mapped[str] = mapped_column(String(100))
+    started_at: Mapped[datetime]
+    duration_ms: Mapped[int]
+    status: Mapped[str] = mapped_column(String(20))  # success, skipped, failed
+    error: Mapped[str | None] = mapped_column(Text, default=None)

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -8,6 +8,7 @@ if the output already exists for the current day/week.
 import asyncio
 import json
 import logging
+import time
 from datetime import date, datetime, timedelta
 
 from sqlalchemy import select
@@ -24,6 +25,7 @@ from mycoach.email.sender import (
 )
 from mycoach.models.activity import Activity
 from mycoach.models.coaching import CoachingInsight
+from mycoach.models.job_run import JobRun
 from mycoach.models.plan import PlannedSession
 from mycoach.models.user import User
 from mycoach.sources.garmin.source import GarminSource
@@ -58,6 +60,67 @@ def _run_job(label: str, coro) -> None:  # type: ignore[no-untyped-def]
         logger.info("Scheduler: %s skipped — %s", label, e)
     except Exception:
         logger.exception("Scheduler: %s failed", label)
+
+
+async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-def]
+    """Run a job body, timing it and recording its outcome durably.
+
+    Writes one append-only ``JobRun`` row — job identifier, start time,
+    duration, status (``success`` / ``skipped`` / ``failed``), and error detail
+    on failure — and emits a structured log line carrying the same facts. A
+    ``PipelineSkip`` is a deliberate no-op (``skipped``); every other exception
+    is a real failure (``failed``). Exceptions never propagate out to the
+    scheduler.
+    """
+    started_at = datetime.utcnow()
+    start = time.perf_counter()
+    status = "success"
+    detail: str | None = None  # skip reason or failure message, for the log line
+    failure: Exception | None = None
+    try:
+        await coro
+    except PipelineSkip as e:
+        status = "skipped"
+        detail = str(e)
+    except Exception as e:  # noqa: BLE001 - outcome is recorded, not re-raised
+        status = "failed"
+        detail = str(e)
+        failure = e
+    duration_ms = int((time.perf_counter() - start) * 1000)
+
+    # The row's error column is failure detail only, per the spec; a skip's
+    # reason is not an error and lives only in the log line below.
+    error = detail if status == "failed" else None
+
+    async with async_session() as session:
+        session.add(
+            JobRun(
+                job_name=job_name,
+                started_at=started_at,
+                duration_ms=duration_ms,
+                status=status,
+                error=error,
+            )
+        )
+        await session.commit()
+
+    extra = {
+        "job_name": job_name,
+        "job_status": status,
+        "job_error": error,
+        "duration_ms": duration_ms,
+    }
+    if status == "failed":
+        logger.error("Scheduler: %s failed", job_name, exc_info=failure, extra=extra)
+    elif status == "skipped":
+        logger.info("Scheduler: %s skipped — %s", job_name, detail, extra=extra)
+    else:
+        logger.info("Scheduler: %s succeeded", job_name, extra=extra)
+
+
+def _run_recorded_job(job_name: str, coro) -> None:  # type: ignore[no-untyped-def]
+    """Sync entry point for a recorded job — the single call site per job."""
+    _run_async(_record_run(job_name, coro))
 
 
 async def _get_user_email_pref(pref_field: str) -> bool:
@@ -104,7 +167,7 @@ async def _garmin_sync() -> None:
 def job_daily_briefing() -> None:
     """Generate the daily coaching briefing."""
     logger.info("Scheduler: generating daily briefing")
-    _run_job("daily briefing", _daily_briefing())
+    _run_recorded_job("daily_briefing", _daily_briefing())
 
 
 async def _daily_briefing() -> None:

--- a/tests/test_logging/test_logging_config.py
+++ b/tests/test_logging/test_logging_config.py
@@ -70,6 +70,28 @@ class TestJSONFormatter:
         assert data["status_code"] == 200
         assert data["duration_ms"] == 12.3
 
+    def test_job_run_fields_propagated(self) -> None:
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="mycoach.scheduler.jobs",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=1,
+            msg="Scheduler: daily_briefing failed",
+            args=(),
+            exc_info=None,
+        )
+        record.job_name = "daily_briefing"  # type: ignore[attr-defined]
+        record.job_status = "failed"  # type: ignore[attr-defined]
+        record.job_error = "boom"  # type: ignore[attr-defined]
+        record.duration_ms = 42  # type: ignore[attr-defined]
+        output = formatter.format(record)
+        data = json.loads(output)
+        assert data["job_name"] == "daily_briefing"
+        assert data["job_status"] == "failed"
+        assert data["job_error"] == "boom"
+        assert data["duration_ms"] == 42
+
     def test_output_is_single_line(self) -> None:
         formatter = JSONFormatter()
         record = logging.LogRecord(

--- a/tests/test_scheduler/test_job_runs.py
+++ b/tests/test_scheduler/test_job_runs.py
@@ -1,0 +1,162 @@
+"""Tests for durable scheduled-job run recording.
+
+Drive a job body through the recording helper and assert on the persisted
+``JobRun`` rows, following the scheduler job-test prior art in ``test_jobs.py``.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from mycoach.coaching.exceptions import PipelineSkip
+from mycoach.models.job_run import JobRun
+from mycoach.scheduler.jobs import _daily_briefing, _record_run
+from tests.conftest import test_session
+
+
+async def _job_runs() -> list[JobRun]:
+    async with test_session() as session:
+        result = await session.execute(select(JobRun).order_by(JobRun.id))
+        return list(result.scalars().all())
+
+
+async def test_records_success() -> None:
+    """A body that returns normally records a single success row."""
+
+    async def body() -> None:
+        return None
+
+    with patch("mycoach.scheduler.jobs.async_session", test_session):
+        await _record_run("daily_briefing", body())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    run = runs[0]
+    assert run.job_name == "daily_briefing"
+    assert run.status == "success"
+    assert run.error is None
+    assert run.duration_ms >= 0
+    assert run.started_at is not None
+
+
+async def test_records_skip() -> None:
+    """A PipelineSkip is recorded as a skipped run with the skip detail."""
+
+    async def body() -> None:
+        raise PipelineSkip("Daily briefing already exists")
+
+    with patch("mycoach.scheduler.jobs.async_session", test_session):
+        await _record_run("daily_briefing", body())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "skipped"
+    # A skip is not an error, so no detail is persisted in the error column;
+    # the skip reason lives only in the structured log line.
+    assert runs[0].error is None
+
+
+async def test_records_failure_with_error_detail() -> None:
+    """Any non-skip exception is recorded as failed with the error detail."""
+
+    async def body() -> None:
+        raise RuntimeError("LLM call blew up")
+
+    with patch("mycoach.scheduler.jobs.async_session", test_session):
+        await _record_run("daily_briefing", body())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].error == "LLM call blew up"
+
+
+async def test_failure_is_not_re_raised() -> None:
+    """The helper swallows the failure so the scheduler thread never crashes."""
+
+    async def body() -> None:
+        raise RuntimeError("boom")
+
+    with patch("mycoach.scheduler.jobs.async_session", test_session):
+        await _record_run("daily_briefing", body())  # must not raise
+
+    assert (await _job_runs())[0].status == "failed"
+
+
+async def test_log_line_carries_job_fields(caplog: pytest.LogCaptureFixture) -> None:
+    """The structured log line carries the same facts as the persisted row."""
+
+    async def body() -> None:
+        raise RuntimeError("kaboom")
+
+    with (
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        caplog.at_level(logging.INFO),
+    ):
+        await _record_run("daily_briefing", body())
+
+    failed = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert failed
+    record = failed[0]
+    assert record.job_name == "daily_briefing"
+    assert record.job_status == "failed"
+    assert record.job_error == "kaboom"
+    assert record.duration_ms is not None
+
+
+async def test_daily_briefing_body_records_run() -> None:
+    """Driving the real daily-briefing body through the helper records a run."""
+    mock_engine = MagicMock()
+    mock_engine.generate_daily_briefing = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _record_run("daily_briefing", _daily_briefing())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].job_name == "daily_briefing"
+    assert runs[0].status == "success"
+    mock_engine.generate_daily_briefing.assert_awaited_once()
+
+
+async def test_daily_briefing_body_records_skip() -> None:
+    """A PipelineSkip out of the real body records a skipped run."""
+    mock_engine = MagicMock()
+    mock_engine.generate_daily_briefing = AsyncMock(
+        side_effect=PipelineSkip("Daily briefing already exists")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+    ):
+        await _record_run("daily_briefing", _daily_briefing())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "skipped"
+
+
+async def test_daily_briefing_body_records_failure() -> None:
+    """A real failure out of the body records a failed run with the detail."""
+    mock_engine = MagicMock()
+    mock_engine.generate_daily_briefing = AsyncMock(
+        side_effect=RuntimeError("Gemini call failed")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+    ):
+        await _record_run("daily_briefing", _daily_briefing())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].error == "Gemini call failed"

--- a/tests/test_scheduler/test_jobs.py
+++ b/tests/test_scheduler/test_jobs.py
@@ -135,7 +135,7 @@ def test_daily_briefing_job_logs_skip(
         job_daily_briefing()  # must not raise
 
     skip_logs = [
-        r for r in caplog.records if "daily briefing skipped" in r.message
+        r for r in caplog.records if "daily_briefing skipped" in r.message
     ]
     assert skip_logs and all(r.levelno == logging.INFO for r in skip_logs)
     assert not any(r.levelno >= logging.ERROR for r in caplog.records)
@@ -162,7 +162,7 @@ def test_daily_briefing_job_logs_malformed_response_as_failure(
         job_daily_briefing()  # must not raise
 
     assert any(
-        r.levelno == logging.ERROR and "daily briefing failed" in r.message
+        r.levelno == logging.ERROR and "daily_briefing failed" in r.message
         for r in caplog.records
     )
     assert not any("skipped" in r.message for r in caplog.records)


### PR DESCRIPTION
Establish durable run recording, proven end-to-end on the daily briefing as a tracer bullet: one job cutting the full path through model, migration, recording helper, and log formatting. A job that ran and failed is no longer indistinguishable from one that never ran.

- Add JobRun model + migration: an append-only, write-only row capturing job identifier, start time, duration_ms, status (success/skipped/failed), and error detail on failure. Nothing reads it; idempotency still comes from the existing-insight check, never from run history.
- Add _record_run: a single helper wrapping a job body, timing it, classifying the outcome on the PipelineSkip boundary (skip vs failure), writing the row and emitting a structured log line carrying the same facts. job_daily_briefing routes through it via _run_recorded_job; the other jobs keep _run_job until the pattern is extended (separate follow-up).
- Propagate job_name/job_status/job_error/duration_ms through JSONFormatter so log aggregation consumes the fields without further integration.
- Drive the real body through success, skip, and failure and assert on the resulting rows, following the existing scheduler job-test prior art.

Closes #7