### PR TITLE
feat(email): redesign templates and wire real coaching data into them

### DIFF
--- a/src/mycoach/config.py
+++ b/src/mycoach/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     api_token: str = ""
     timezone: str = "Europe/London"
+    app_base_url: str = "http://localhost:8000"  # links back into emails (e.g. dashboard CTA)
 
     # Security
     encryption_key: str = ""  # Fernet key for encrypting credentials at rest

--- a/src/mycoach/email/sender.py
+++ b/src/mycoach/email/sender.py
@@ -30,6 +30,33 @@ def _render_template(template_name: str, context: dict) -> str:  # type: ignore[
     return template.render(**context)
 
 
+# Display label/unit for each DailyBriefingKeyMetrics field, in the order
+# emails should show them. Keys absent or None are skipped.
+_KEY_METRICS_DISPLAY: dict[str, tuple[str, str]] = {
+    "body_battery": ("Body Battery", ""),
+    "hrv_status": ("HRV Status", ""),
+    "sleep_score": ("Sleep Score", ""),
+    "training_readiness": ("Training Readiness", ""),
+    "resting_hr": ("Resting HR", "bpm"),
+}
+
+
+def _format_key_metrics(key_metrics: dict) -> list[dict]:  # type: ignore[type-arg]
+    """Turn the raw DailyBriefingKeyMetrics fields into display-ready rows."""
+    rows = []
+    for key, (label, unit) in _KEY_METRICS_DISPLAY.items():
+        value = key_metrics.get(key)
+        if value is None:
+            continue
+        rows.append({"label": label, "value": value, "unit": unit})
+    return rows
+
+
+def _dashboard_url(settings: Settings) -> str:
+    """Build the dashboard link used for every email's CTA button."""
+    return f"{settings.app_base_url}/dashboard"
+
+
 def _send_via_resend(settings: Settings, to: str, subject: str, html: str) -> bool:
     """Send email using Resend API."""
     resend.api_key = settings.email_resend_api_key
@@ -95,7 +122,13 @@ def send_daily_briefing(content: dict, settings: Settings | None = None) -> bool
     """Send the daily coaching briefing email."""
     if settings is None:
         settings = get_settings()
-    html = _render_template("daily_briefing.html", {"briefing": content})
+    briefing = dict(content)
+    if briefing.get("key_metrics"):
+        briefing["key_metrics"] = _format_key_metrics(briefing["key_metrics"])
+    html = _render_template(
+        "daily_briefing.html",
+        {"briefing": briefing, "dashboard_url": _dashboard_url(settings)},
+    )
     return send_email(settings.email_to, "MyCoach — Daily Briefing", html, settings)
 
 
@@ -110,7 +143,12 @@ def send_weekly_plan(
         settings = get_settings()
     html = _render_template(
         "weekly_plan.html",
-        {"summary": summary, "sessions": sessions, "week_start": week_start},
+        {
+            "summary": summary,
+            "sessions": sessions,
+            "week_start": week_start,
+            "dashboard_url": _dashboard_url(settings),
+        },
     )
     return send_email(settings.email_to, "MyCoach — Weekly Plan", html, settings)
 
@@ -120,7 +158,12 @@ def send_post_workout(content: dict, activity_title: str, settings: Settings | N
     if settings is None:
         settings = get_settings()
     html = _render_template(
-        "post_workout.html", {"analysis": content, "activity_title": activity_title}
+        "post_workout.html",
+        {
+            "analysis": content,
+            "activity_title": activity_title,
+            "dashboard_url": _dashboard_url(settings),
+        },
     )
     return send_email(
         settings.email_to, f"MyCoach — Post-Workout: {activity_title}", html, settings
@@ -132,5 +175,8 @@ def send_weekly_recap(content: dict, week_start: str, settings: Settings | None 
     """Send weekly recap email."""
     if settings is None:
         settings = get_settings()
-    html = _render_template("weekly_recap.html", {"recap": content, "week_start": week_start})
+    html = _render_template(
+        "weekly_recap.html",
+        {"recap": content, "week_start": week_start, "dashboard_url": _dashboard_url(settings)},
+    )
     return send_email(settings.email_to, "MyCoach — Weekly Recap", html, settings)

--- a/src/mycoach/email/templates/base.html
+++ b/src/mycoach/email/templates/base.html
@@ -3,41 +3,120 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <title>{% block title %}MyCoach{% endblock %}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
 <style>
-  body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f3f4f6; color: #1f2937; }
-  .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
-  .header { background-color: #1e40af; color: #ffffff; padding: 20px 24px; }
-  .header h1 { margin: 0; font-size: 20px; font-weight: 700; }
-  .header p { margin: 4px 0 0; font-size: 13px; color: #bfdbfe; }
-  .content { padding: 24px; }
-  .footer { padding: 16px 24px; text-align: center; font-size: 12px; color: #9ca3af; border-top: 1px solid #e5e7eb; }
-  .card { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
-  .card h3 { margin: 0 0 8px; font-size: 15px; color: #1e40af; }
-  .badge { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 12px; font-weight: 600; }
-  .badge-green { background: #dcfce7; color: #166534; }
-  .badge-yellow { background: #fef9c3; color: #854d0e; }
-  .badge-red { background: #fee2e2; color: #991b1b; }
-  .badge-blue { background: #dbeafe; color: #1e40af; }
-  .metric { display: inline-block; text-align: center; padding: 8px 12px; }
-  .metric-value { font-size: 20px; font-weight: 700; color: #111827; }
-  .metric-label { font-size: 11px; color: #6b7280; text-transform: uppercase; }
-  ul { padding-left: 20px; }
-  li { margin-bottom: 4px; }
+  :root { color-scheme: light dark; supported-color-schemes: light dark; }
+  body { margin:0; padding:0; background:#f0efec; -webkit-font-smoothing:antialiased; -webkit-text-size-adjust:100%; }
+  table { border-collapse:collapse; }
+  img { border:0; line-height:100%; }
+  a { text-decoration:none; }
+
+  .wrap { width:100%; background:#f0efec; padding:26px 0; }
+  .email { max-width:420px; margin:0 auto; background:#ffffff; border:1px solid rgba(0,0,0,.08); border-radius:16px; overflow:hidden; }
+  .px { padding-left:24px; padding-right:24px; }
+
+  .hd-b { border-bottom:1px solid rgba(0,0,0,.08); }
+  .dot { display:inline-block; width:9px; height:9px; border-radius:3px; background:#ea6d1f; vertical-align:middle; margin-right:9px; }
+  .brand { font:700 15px 'IBM Plex Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; color:#18191b; vertical-align:middle; }
+  .hd-meta { font:400 11px 'IBM Plex Mono',ui-monospace,Menlo,monospace; color:#78716c; }
+
+  .eyebrow { font:600 11px 'IBM Plex Sans',sans-serif; letter-spacing:.16em; text-transform:uppercase; color:#78716c; }
+  .sec { font:600 11px 'IBM Plex Sans',sans-serif; letter-spacing:.14em; text-transform:uppercase; color:#78716c; }
+  .verdict { font:700 46px/1 'IBM Plex Sans',-apple-system,sans-serif; letter-spacing:-.02em; color:#18191b; }
+  .rule { width:120px; height:5px; border-radius:3px; background:#ea6d1f; font-size:0; line-height:0; }
+  .lead { font:400 15px/1.55 'IBM Plex Sans',sans-serif; color:#52525b; }
+  .p { font:400 14px/1.7 'IBM Plex Sans',sans-serif; color:#3f3f46; }
+  .strong { color:#18191b; font-weight:600; }
+
+  .block-b { border-top:1px solid rgba(0,0,0,.08); }
+  .mrow { border-bottom:1px solid rgba(0,0,0,.06); }
+  .mlabel { font:500 13px 'IBM Plex Sans',sans-serif; color:#3f3f46; }
+  .msub { font:400 11px 'IBM Plex Mono',monospace; color:#a1a1aa; }
+  .mval { font:600 17px 'IBM Plex Mono',ui-monospace,Menlo,monospace; color:#18191b; text-align:right; white-space:nowrap; }
+  .munit { font-size:12px; color:#a1a1aa; }
+
+  .coach { background:rgba(234,109,31,.07); border:1px solid rgba(234,109,31,.28); border-radius:10px; }
+  .coach-k { font:600 11px 'IBM Plex Sans',sans-serif; letter-spacing:.08em; text-transform:uppercase; color:#c2560f; }
+  .coach-t { font:400 14px/1.55 'IBM Plex Sans',sans-serif; color:#7c4a26; }
+
+  .li { font:400 14px/1.5 'IBM Plex Sans',sans-serif; color:#3f3f46; }
+  .mk-plus { font:600 14px 'IBM Plex Mono',monospace; color:#c2560f; }
+  .mk-arrow { font:600 14px 'IBM Plex Mono',monospace; color:#9ca3af; }
+
+  .badge { display:inline-block; font:600 11px 'IBM Plex Sans',sans-serif; letter-spacing:.03em; padding:4px 10px; border-radius:999px; }
+  .b-amber { background:rgba(234,109,31,.10); color:#c2560f; }
+  .b-emerald { background:rgba(5,150,105,.12); color:#047857; }
+  .b-sky { background:rgba(2,132,199,.12); color:#0369a1; }
+  .b-zinc { background:rgba(0,0,0,.06); color:#52525b; }
+
+  .cta { display:block; text-align:center; font:700 15px 'IBM Plex Sans',sans-serif; color:#ffffff !important; background:#ea6d1f; padding:15px 0; border-radius:12px; }
+
+  .ft { border-top:1px solid rgba(0,0,0,.08); background:#faf9f7; }
+  .ft-t { font:400 12px/1.6 'IBM Plex Sans',sans-serif; color:#a1a1aa; }
+  .ft-t a { color:#78716c; }
+
+  @media (prefers-color-scheme: dark) {
+    body, .wrap { background:#08090a !important; }
+    .email { background:#0b0c0e !important; border-color:rgba(255,255,255,.08) !important; }
+    .hd-b, .block-b, .ft { border-color:rgba(255,255,255,.08) !important; }
+    .ft { background:#0a0b0c !important; }
+    .brand, .verdict, .strong, .mval { color:#fafafa !important; }
+    .hd-meta, .eyebrow, .sec, .mk-arrow, .msub, .munit { color:#6b7280 !important; }
+    .lead, .mlabel { color:#a1a1aa !important; }
+    .p, .li { color:#c9c9cd !important; }
+    .rule { background:#fb923c !important; }
+    .coach { background:rgba(251,146,60,.09) !important; border-color:rgba(251,146,60,.22) !important; }
+    .coach-k, .mk-plus { color:#fb923c !important; }
+    .coach-t { color:#e4c9ac !important; }
+    .mrow { border-color:rgba(255,255,255,.06) !important; }
+    .b-amber { background:rgba(251,146,60,.13) !important; color:#fdba74 !important; }
+    .b-emerald { background:rgba(16,185,129,.15) !important; color:#6ee7b7 !important; }
+    .b-sky { background:rgba(56,189,248,.15) !important; color:#7dd3fc !important; }
+    .b-zinc { background:rgba(255,255,255,.08) !important; color:#a1a1aa !important; }
+    .cta { background:#fb923c !important; color:#0a0b0d !important; }
+    .ft-t { color:#57575c !important; }
+    .ft-t a { color:#78716c !important; }
+  }
 </style>
 </head>
 <body>
-<div class="container">
-  <div class="header">
-    <h1>MyCoach</h1>
-    <p>{% block subtitle %}{% endblock %}</p>
-  </div>
-  <div class="content">
-    {% block content %}{% endblock %}
-  </div>
-  <div class="footer">
-    MyCoach &mdash; AI-powered personal fitness coaching
-  </div>
+<div class="wrap">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td align="center">
+        <table role="presentation" class="email" width="420" cellpadding="0" cellspacing="0" border="0" align="center">
+
+          <!-- Header -->
+          <tr>
+            <td class="px hd-b" style="padding-top:18px;padding-bottom:18px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td style="vertical-align:middle;"><span class="dot"></span><span class="brand">MyCoach</span></td>
+                  <td class="hd-meta" style="text-align:right;vertical-align:middle;">{% block subtitle %}{% endblock %}</td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          {% block content %}{% endblock %}
+
+          <!-- Footer -->
+          <tr>
+            <td class="ft px" style="padding-top:18px;padding-bottom:22px;">
+              <div class="ft-t">MyCoach &mdash; AI-powered personal fitness coaching.</div>
+              <div class="ft-t" style="margin-top:6px;"><a href="{{ manage_url|default('#') }}">Manage emails</a> &middot; <a href="{{ unsubscribe_url|default('#') }}">Unsubscribe</a></div>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/src/mycoach/email/templates/daily_briefing.html
+++ b/src/mycoach/email/templates/daily_briefing.html
@@ -1,48 +1,76 @@
 {% extends "base.html" %}
 {% block title %}Daily Briefing{% endblock %}
-{% block subtitle %}Daily Coaching Briefing{% endblock %}
+{% block subtitle %}Daily briefing{% endblock %}
 {% block content %}
-<div class="card">
-  <h3>Readiness</h3>
-  {% if briefing.readiness_verdict == "go_hard" %}
-  <span class="badge badge-green">Go Hard</span>
-  {% elif briefing.readiness_verdict == "moderate" %}
-  <span class="badge badge-yellow">Moderate</span>
-  {% elif briefing.readiness_verdict == "active_recovery" %}
-  <span class="badge badge-yellow">Active Recovery</span>
-  {% else %}
-  <span class="badge badge-red">Rest</span>
-  {% endif %}
-  <p>{{ briefing.recovery_status }}</p>
-</div>
+{% set _vmap = {'go_hard': 'Go Hard', 'moderate': 'Moderate', 'active_recovery': 'Active Recovery', 'rest': 'Rest'} %}
 
-<div class="card">
-  <h3>Sleep Assessment</h3>
-  <p>{{ briefing.sleep_assessment }}</p>
-</div>
-
-{% if briefing.workout_adjustments %}
-<div class="card">
-  <h3>Workout Adjustments</h3>
-  <p>{{ briefing.workout_adjustments }}</p>
-</div>
-{% endif %}
+<!-- Hero: readiness verdict -->
+<tr>
+  <td class="px" style="padding-top:26px;padding-bottom:20px;">
+    <div class="eyebrow">Today's readiness</div>
+    <div class="verdict" style="margin-top:12px;">{{ _vmap.get(briefing.readiness_verdict, 'Moderate') }}</div>
+    <div class="rule" style="margin-top:16px;">&nbsp;</div>
+    {% if briefing.recovery_status %}
+    <div class="lead" style="margin-top:14px;">{{ briefing.recovery_status }}</div>
+    {% endif %}
+    {% if briefing.readiness_explanation %}
+    <div class="lead" style="margin-top:10px;">{{ briefing.readiness_explanation }}</div>
+    {% endif %}
+  </td>
+</tr>
 
 {% if briefing.key_metrics %}
-<div class="card">
-  <h3>Key Metrics</h3>
-  <ul>
-  {% for key, value in briefing.key_metrics.items() %}
-    <li><strong>{{ key }}:</strong> {{ value }}</li>
-  {% endfor %}
-  </ul>
-</div>
+<!-- Key metrics -->
+<tr>
+  <td class="px" style="padding-top:6px;padding-bottom:6px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-top:1px solid rgba(0,0,0,.08);">
+      {% for metric in briefing.key_metrics %}
+      <tr>
+        <td class="mrow mlabel" style="padding:12px 0;">{{ metric.label }}</td>
+        <td class="mrow mval" style="padding:12px 0;">{{ metric.value }}{% if metric.unit %} <span class="munit">{{ metric.unit }}</span>{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </td>
+</tr>
+{% endif %}
+
+{% if briefing.sleep_assessment %}
+<!-- Sleep assessment -->
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Sleep assessment</div>
+    <div class="p">{{ briefing.sleep_assessment }}</div>
+  </td>
+</tr>
+{% endif %}
+
+{% if briefing.workout_adjustments %}
+<!-- Workout adjustments -->
+<tr>
+  <td class="px" style="padding-top:20px;padding-bottom:2px;">
+    <div class="coach" style="padding:14px 16px;">
+      <div class="coach-k">Coach adjustment</div>
+      <div class="coach-t" style="margin-top:5px;">{{ briefing.workout_adjustments }}</div>
+    </div>
+  </td>
+</tr>
 {% endif %}
 
 {% if briefing.sleep_recommendation %}
-<div class="card">
-  <h3>Tonight's Sleep Recommendation</h3>
-  <p>{{ briefing.sleep_recommendation }}</p>
-</div>
+<!-- Tonight -->
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;margin-top:20px;">
+    <div class="sec" style="margin-bottom:8px;">Tonight</div>
+    <div class="p">{{ briefing.sleep_recommendation }}</div>
+  </td>
+</tr>
 {% endif %}
+
+<!-- CTA -->
+<tr>
+  <td class="px" style="padding-top:24px;padding-bottom:28px;">
+    <a href="{{ dashboard_url|default('#') }}" class="cta">Open dashboard &rarr;</a>
+  </td>
+</tr>
 {% endblock %}

--- a/src/mycoach/email/templates/post_workout.html
+++ b/src/mycoach/email/templates/post_workout.html
@@ -1,66 +1,102 @@
 {% extends "base.html" %}
 {% block title %}Post-Workout Analysis{% endblock %}
-{% block subtitle %}Post-Workout Analysis &mdash; {{ activity_title }}{% endblock %}
+{% block subtitle %}Post-workout{% endblock %}
 {% block content %}
-<div class="card">
-  <h3>Performance Summary</h3>
-  <p>{{ analysis.performance_summary }}</p>
-</div>
+
+<!-- Activity title + performance summary -->
+<tr>
+  <td class="px" style="padding-top:26px;padding-bottom:18px;">
+    <div class="eyebrow">Session analysis</div>
+    <div class="verdict" style="font-size:30px;line-height:1.15;margin-top:10px;">{{ activity_title }}</div>
+    {% if analysis.performance_summary %}
+    <div class="rule" style="margin-top:16px;">&nbsp;</div>
+    <div class="lead" style="margin-top:14px;">{{ analysis.performance_summary }}</div>
+    {% endif %}
+  </td>
+</tr>
 
 {% if analysis.planned_vs_actual %}
-<div class="card">
-  <h3>Planned vs Actual</h3>
-  <p>{{ analysis.planned_vs_actual }}</p>
-</div>
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Planned vs actual</div>
+    <div class="p">{{ analysis.planned_vs_actual }}</div>
+  </td>
+</tr>
 {% endif %}
 
 {% if analysis.hr_analysis %}
-<div class="card">
-  <h3>Heart Rate Analysis</h3>
-  <p>{{ analysis.hr_analysis }}</p>
-</div>
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Heart rate</div>
+    <div class="p">{{ analysis.hr_analysis }}</div>
+  </td>
+</tr>
 {% endif %}
 
 {% if analysis.performance_trends %}
-<div class="card">
-  <h3>Performance Trends</h3>
-  <p>{{ analysis.performance_trends }}</p>
-</div>
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Trends</div>
+    <div class="p">{{ analysis.performance_trends }}</div>
+  </td>
+</tr>
 {% endif %}
 
 {% if analysis.key_highlights %}
-<div class="card">
-  <h3>Highlights</h3>
-  <ul>
-  {% for item in analysis.key_highlights %}
-    <li>{{ item }}</li>
-  {% endfor %}
-  </ul>
-</div>
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:6px;">
+    <div class="sec" style="margin-bottom:10px;">Highlights</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      {% for item in analysis.key_highlights %}
+      <tr>
+        <td style="width:22px;vertical-align:top;padding:5px 0;"><span class="mk-plus">+</span></td>
+        <td class="li" style="padding:5px 0;">{{ item }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </td>
+</tr>
 {% endif %}
 
 {% if analysis.areas_for_improvement %}
-<div class="card">
-  <h3>Areas for Improvement</h3>
-  <ul>
-  {% for item in analysis.areas_for_improvement %}
-    <li>{{ item }}</li>
-  {% endfor %}
-  </ul>
-</div>
+<tr>
+  <td class="px" style="padding-top:16px;padding-bottom:6px;">
+    <div class="sec" style="margin-bottom:10px;">Work on</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      {% for item in analysis.areas_for_improvement %}
+      <tr>
+        <td style="width:22px;vertical-align:top;padding:5px 0;"><span class="mk-arrow">&rarr;</span></td>
+        <td class="li" style="padding:5px 0;">{{ item }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </td>
+</tr>
 {% endif %}
 
 {% if analysis.next_session_recommendations %}
-<div class="card">
-  <h3>Next Session Recommendations</h3>
-  <p>{{ analysis.next_session_recommendations }}</p>
-</div>
+<tr>
+  <td class="px" style="padding-top:16px;padding-bottom:2px;">
+    <div class="coach" style="padding:14px 16px;">
+      <div class="coach-k">Next session</div>
+      <div class="coach-t" style="margin-top:5px;">{{ analysis.next_session_recommendations }}</div>
+    </div>
+  </td>
+</tr>
 {% endif %}
 
 {% if analysis.recovery_notes %}
-<div class="card">
-  <h3>Recovery Notes</h3>
-  <p>{{ analysis.recovery_notes }}</p>
-</div>
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Recovery</div>
+    <div class="p">{{ analysis.recovery_notes }}</div>
+  </td>
+</tr>
 {% endif %}
+
+<tr>
+  <td class="px" style="padding-top:24px;padding-bottom:28px;">
+    <a href="{{ dashboard_url|default('#') }}" class="cta">View full report &rarr;</a>
+  </td>
+</tr>
 {% endblock %}

--- a/src/mycoach/email/templates/weekly_plan.html
+++ b/src/mycoach/email/templates/weekly_plan.html
@@ -1,29 +1,59 @@
 {% extends "base.html" %}
 {% block title %}Weekly Plan{% endblock %}
-{% block subtitle %}Weekly Training Plan &mdash; Week of {{ week_start }}{% endblock %}
+{% block subtitle %}Weekly plan{% endblock %}
 {% block content %}
-{% if summary %}
-<div class="card">
-  <h3>Plan Summary</h3>
-  <p>{{ summary }}</p>
-</div>
-{% endif %}
+{% set _sportbadge = {'gym': 'b-amber', 'strength': 'b-amber', 'swimming': 'b-sky', 'swim': 'b-sky', 'cycling': 'b-sky', 'running': 'b-emerald', 'run': 'b-emerald', 'padel': 'b-emerald', 'rest': 'b-zinc'} %}
 
+<!-- Hero -->
+<tr>
+  <td class="px" style="padding-top:26px;padding-bottom:18px;">
+    <div class="eyebrow">Week of {{ week_start }}</div>
+    <div class="verdict" style="font-size:38px;margin-top:10px;">Weekly Plan</div>
+    <div class="rule" style="margin-top:16px;">&nbsp;</div>
+    {% if summary %}
+    <div class="lead" style="margin-top:14px;">{{ summary }}</div>
+    {% endif %}
+  </td>
+</tr>
+
+<!-- Sessions -->
 {% for session in sessions %}
-<div class="card">
-  <h3>{{ session.day_name }} &mdash; {{ session.title }}</h3>
-  <p>
-    <span class="badge badge-blue">{{ session.sport }}</span>
-    {% if session.duration_minutes %} &bull; {{ session.duration_minutes }} min{% endif %}
-  </p>
-  {% if session.notes %}<p>{{ session.notes }}</p>{% endif %}
-  {% if session.details %}
-  <ul>
-  {% for key, value in session.details.items() %}
-    <li><strong>{{ key }}:</strong> {{ value }}</li>
-  {% endfor %}
-  </ul>
-  {% endif %}
-</div>
+<tr>
+  <td class="px block-b" style="padding-top:18px;padding-bottom:18px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td style="vertical-align:top;">
+          <div class="msub" style="text-transform:uppercase;letter-spacing:.1em;">{{ session.day_name }}</div>
+          <div class="strong" style="font:600 17px 'IBM Plex Sans',sans-serif;margin-top:3px;">{{ session.title }}</div>
+        </td>
+        <td style="vertical-align:top;text-align:right;white-space:nowrap;">
+          <span class="badge {{ _sportbadge.get(session.sport|lower, 'b-zinc') }}">{{ session.sport }}</span>
+        </td>
+      </tr>
+    </table>
+    {% if session.duration_minutes %}
+    <div class="msub" style="margin-top:8px;">{{ session.duration_minutes }} min</div>
+    {% endif %}
+    {% if session.notes %}
+    <div class="p" style="margin-top:8px;">{{ session.notes }}</div>
+    {% endif %}
+    {% if session.details and session.details.exercises %}
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:10px;">
+      {% for ex in session.details.exercises %}
+      <tr>
+        <td class="mlabel" style="padding:6px 0;font-weight:400;color:#78716c;">{{ ex.name }}</td>
+        <td class="mval" style="padding:6px 0;font-size:13px;">{{ ex.sets }}&times;{{ ex.reps }}{% if ex.target_weight_kg %} @ {{ ex.target_weight_kg }}kg{% endif %}{% if ex.rpe %} &middot; RPE {{ ex.rpe }}{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </table>
+    {% endif %}
+  </td>
+</tr>
 {% endfor %}
+
+<tr>
+  <td class="px" style="padding-top:22px;padding-bottom:28px;">
+    <a href="{{ dashboard_url|default('#') }}" class="cta">Open this week &rarr;</a>
+  </td>
+</tr>
 {% endblock %}

--- a/src/mycoach/email/templates/weekly_recap.html
+++ b/src/mycoach/email/templates/weekly_recap.html
@@ -1,66 +1,118 @@
 {% extends "base.html" %}
 {% block title %}Weekly Recap{% endblock %}
-{% block subtitle %}Weekly Recap &mdash; Week of {{ week_start }}{% endblock %}
+{% block subtitle %}Weekly recap{% endblock %}
 {% block content %}
-<div class="card">
-  <h3>Week Summary</h3>
-  <p>{{ recap.week_summary }}</p>
-</div>
+
+<!-- Hero -->
+<tr>
+  <td class="px" style="padding-top:26px;padding-bottom:18px;">
+    <div class="eyebrow">Week of {{ week_start }}</div>
+    <div class="verdict" style="font-size:38px;margin-top:10px;">Weekly Recap</div>
+    <div class="rule" style="margin-top:16px;">&nbsp;</div>
+    {% if recap.week_summary %}
+    <div class="lead" style="margin-top:14px;">{{ recap.week_summary }}</div>
+    {% endif %}
+  </td>
+</tr>
 
 {% if recap.adherence_analysis %}
-<div class="card">
-  <h3>Adherence Analysis</h3>
-  <p>{{ recap.adherence_analysis }}</p>
-</div>
-{% endif %}
-
-{% if recap.performance_highlights %}
-<div class="card">
-  <h3>Performance Highlights</h3>
-  <ul>
-  {% for item in recap.performance_highlights %}
-    <li>{{ item }}</li>
-  {% endfor %}
-  </ul>
-</div>
-{% endif %}
-
-{% if recap.areas_of_concern %}
-<div class="card">
-  <h3>Areas of Concern</h3>
-  <ul>
-  {% for item in recap.areas_of_concern %}
-    <li>{{ item }}</li>
-  {% endfor %}
-  </ul>
-</div>
-{% endif %}
-
-{% if recap.recovery_assessment %}
-<div class="card">
-  <h3>Recovery Assessment</h3>
-  <p>{{ recap.recovery_assessment }}</p>
-</div>
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Adherence</div>
+    <div class="p">{{ recap.adherence_analysis }}</div>
+  </td>
+</tr>
 {% endif %}
 
 {% if recap.training_load_analysis %}
-<div class="card">
-  <h3>Training Load Analysis</h3>
-  <p>{{ recap.training_load_analysis }}</p>
-</div>
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Training load</div>
+    <div class="p">{{ recap.training_load_analysis }}</div>
+  </td>
+</tr>
+{% endif %}
+
+{% if recap.recovery_assessment %}
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Recovery</div>
+    <div class="p">{{ recap.recovery_assessment }}</div>
+  </td>
+</tr>
+{% endif %}
+
+{% if recap.performance_highlights %}
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:6px;">
+    <div class="sec" style="margin-bottom:10px;">Highlights</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      {% for item in recap.performance_highlights %}
+      <tr>
+        <td style="width:22px;vertical-align:top;padding:5px 0;"><span class="mk-plus">+</span></td>
+        <td class="li" style="padding:5px 0;">{{ item }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </td>
+</tr>
+{% endif %}
+
+{% if recap.areas_of_concern %}
+<tr>
+  <td class="px" style="padding-top:16px;padding-bottom:6px;">
+    <div class="sec" style="margin-bottom:10px;">Watch</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      {% for item in recap.areas_of_concern %}
+      <tr>
+        <td style="width:22px;vertical-align:top;padding:5px 0;"><span class="mk-arrow">&rarr;</span></td>
+        <td class="li" style="padding:5px 0;">{{ item }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </td>
+</tr>
 {% endif %}
 
 {% if recap.next_week_recommendations %}
-<div class="card">
-  <h3>Next Week Recommendations</h3>
-  <p>{{ recap.next_week_recommendations }}</p>
-</div>
+<tr>
+  <td class="px" style="padding-top:16px;padding-bottom:2px;">
+    <div class="coach" style="padding:14px 16px;">
+      <div class="coach-k">Next week</div>
+      <div class="coach-t" style="margin-top:5px;">{{ recap.next_week_recommendations }}</div>
+    </div>
+  </td>
+</tr>
 {% endif %}
 
 {% if recap.mesocycle_progress %}
-<div class="card">
-  <h3>Mesocycle Progress</h3>
-  <p>{{ recap.mesocycle_progress }}</p>
-</div>
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Mesocycle</div>
+    <div class="p">{{ recap.mesocycle_progress }}</div>
+  </td>
+</tr>
 {% endif %}
+
+{% if recap.coach_recommendations %}
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:6px;">
+    <div class="sec" style="margin-bottom:10px;">Coach recommendations</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      {% for item in recap.coach_recommendations %}
+      <tr>
+        <td style="width:22px;vertical-align:top;padding:5px 0;"><span class="mk-plus">+</span></td>
+        <td class="li" style="padding:5px 0;">{{ item }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </td>
+</tr>
+{% endif %}
+
+<tr>
+  <td class="px" style="padding-top:24px;padding-bottom:28px;">
+    <a href="{{ dashboard_url|default('#') }}" class="cta">See full recap &rarr;</a>
+  </td>
+</tr>
 {% endblock %}

--- a/tests/test_email/test_sender.py
+++ b/tests/test_email/test_sender.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from mycoach.config import Settings
 from mycoach.email.sender import (
+    _format_key_metrics,
     _render_template,
     send_daily_briefing,
     send_email,
@@ -30,28 +31,50 @@ def _make_settings(**overrides: object) -> Settings:
 
 
 def test_render_daily_briefing_template() -> None:
-    """Daily briefing template renders with readiness verdict."""
+    """Daily briefing template renders readiness verdict, explanation, and formatted metrics."""
     html = _render_template(
         "daily_briefing.html",
         {
             "briefing": {
                 "readiness_verdict": "go_hard",
                 "recovery_status": "Fully recovered",
+                "readiness_explanation": "HRV and sleep both trended up this week",
                 "sleep_assessment": "Good sleep",
                 "workout_adjustments": None,
-                "key_metrics": {"resting_hr": "52 bpm"},
+                "key_metrics": [{"label": "Resting HR", "value": 52, "unit": "bpm"}],
                 "sleep_recommendation": "Sleep by 10pm",
             }
         },
     )
     assert "Go Hard" in html
     assert "Fully recovered" in html
-    assert "52 bpm" in html
+    assert "HRV and sleep both trended up this week" in html
+    assert "Resting HR" in html
+    assert "52" in html
+    assert "bpm" in html
     assert "MyCoach" in html
 
 
+def test_format_key_metrics_maps_labels_and_skips_none() -> None:
+    """_format_key_metrics turns raw field names into display rows, dropping absent values."""
+    rows = _format_key_metrics(
+        {
+            "body_battery": 65,
+            "hrv_status": None,
+            "sleep_score": 78,
+            "training_readiness": None,
+            "resting_hr": 52,
+        }
+    )
+    assert rows == [
+        {"label": "Body Battery", "value": 65, "unit": ""},
+        {"label": "Sleep Score", "value": 78, "unit": ""},
+        {"label": "Resting HR", "value": 52, "unit": "bpm"},
+    ]
+
+
 def test_render_weekly_plan_template() -> None:
-    """Weekly plan template renders sessions."""
+    """Weekly plan template renders sessions and a gym exercise table."""
     html = _render_template(
         "weekly_plan.html",
         {
@@ -63,7 +86,17 @@ def test_render_weekly_plan_template() -> None:
                     "sport": "gym",
                     "duration_minutes": 60,
                     "notes": "Focus on bench",
-                    "details": {"bench_press": "4x8"},
+                    "details": {
+                        "exercises": [
+                            {
+                                "name": "Bench Press",
+                                "sets": 4,
+                                "reps": 8,
+                                "target_weight_kg": 60,
+                                "rpe": 8,
+                            }
+                        ]
+                    },
                 }
             ],
             "week_start": "2025-03-03",
@@ -73,6 +106,33 @@ def test_render_weekly_plan_template() -> None:
     assert "Upper Body" in html
     assert "gym" in html
     assert "2025-03-03" in html
+    assert "Bench Press" in html
+    assert "4" in html and "8" in html
+    assert "60kg" in html
+    assert "RPE 8" in html
+
+
+def test_render_weekly_plan_template_cardio_details_not_rendered() -> None:
+    """Cardio's free-form details dict is not rendered — sessions rely on notes instead."""
+    html = _render_template(
+        "weekly_plan.html",
+        {
+            "summary": "Easy week",
+            "sessions": [
+                {
+                    "day_name": "Tuesday",
+                    "title": "Easy Run",
+                    "sport": "running",
+                    "duration_minutes": 40,
+                    "notes": "Keep it conversational pace",
+                    "details": {"target_pace_min_per_km": 5.5, "hr_zone": 2},
+                }
+            ],
+            "week_start": "2025-03-03",
+        },
+    )
+    assert "Keep it conversational pace" in html
+    assert "target_pace_min_per_km" not in html
 
 
 def test_render_post_workout_template() -> None:
@@ -101,7 +161,7 @@ def test_render_post_workout_template() -> None:
 
 
 def test_render_weekly_recap_template() -> None:
-    """Weekly recap template renders recap fields."""
+    """Weekly recap template renders recap fields, including coach recommendations."""
     html = _render_template(
         "weekly_recap.html",
         {
@@ -114,6 +174,7 @@ def test_render_weekly_recap_template() -> None:
                 "training_load_analysis": "Moderate load",
                 "next_week_recommendations": "Push harder",
                 "mesocycle_progress": "Week 3 of 4",
+                "coach_recommendations": ["Add a third rest day", "Increase protein intake"],
             },
             "week_start": "2025-02-24",
         },
@@ -121,6 +182,8 @@ def test_render_weekly_recap_template() -> None:
     assert "Solid week" in html
     assert "Squat PR" in html
     assert "2025-02-24" in html
+    assert "Add a third rest day" in html
+    assert "Increase protein intake" in html
 
 
 # --- send_email function ---
@@ -245,3 +308,56 @@ def test_send_weekly_recap_calls_send_email(mock_send: MagicMock) -> None:
         settings=settings,
     )
     assert result is True
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_send_daily_briefing_wires_dashboard_url(mock_send: MagicMock) -> None:
+    """send_daily_briefing's CTA points at settings.app_base_url, not a dead '#' link."""
+    settings = _make_settings(app_base_url="https://coach.example.com")
+    send_daily_briefing({"readiness_verdict": "moderate"}, settings=settings)
+    html = mock_send.call_args[0][2]
+    assert "https://coach.example.com/dashboard" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_send_daily_briefing_formats_raw_key_metrics(mock_send: MagicMock) -> None:
+    """send_daily_briefing formats the raw Pydantic-shaped key_metrics before rendering."""
+    settings = _make_settings()
+    send_daily_briefing(
+        {"readiness_verdict": "moderate", "key_metrics": {"resting_hr": 52, "hrv_status": None}},
+        settings=settings,
+    )
+    html = mock_send.call_args[0][2]
+    assert "Resting HR" in html
+    assert "52" in html
+    assert "bpm" in html
+    assert "HRV Status" not in html  # None values are skipped
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_send_weekly_plan_wires_dashboard_url(mock_send: MagicMock) -> None:
+    """send_weekly_plan's CTA points at settings.app_base_url, not a dead '#' link."""
+    settings = _make_settings(app_base_url="https://coach.example.com")
+    send_weekly_plan(summary="Good week", sessions=[], week_start="2025-03-03", settings=settings)
+    html = mock_send.call_args[0][2]
+    assert "https://coach.example.com/dashboard" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_send_post_workout_wires_dashboard_url(mock_send: MagicMock) -> None:
+    """send_post_workout's CTA points at settings.app_base_url, not a dead '#' link."""
+    settings = _make_settings(app_base_url="https://coach.example.com")
+    send_post_workout(
+        content={"performance_summary": "Great"}, activity_title="Leg Day", settings=settings
+    )
+    html = mock_send.call_args[0][2]
+    assert "https://coach.example.com/dashboard" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_send_weekly_recap_wires_dashboard_url(mock_send: MagicMock) -> None:
+    """send_weekly_recap's CTA points at settings.app_base_url, not a dead '#' link."""
+    settings = _make_settings(app_base_url="https://coach.example.com")
+    send_weekly_recap(content={"week_summary": "Solid"}, week_start="2025-02-24", settings=settings)
+    html = mock_send.call_args[0][2]
+    assert "https://coach.example.com/dashboard" in html


### PR DESCRIPTION
Replaces the plain card-based email templates with a Claude-Design visual redesign (typography, dark mode, badges), then closes gaps the redesign exposed: key_metrics arrives as raw Pydantic field names and is now mapped to display labels/units; gym session details render a real exercise table instead of dumping nested JSON; weekly recap's coach_recommendations and daily briefing's readiness_explanation were generated by the LLM but never shown, so both are now rendered; and every email's CTA links to a real dashboard URL via a new app_base_url setting instead of a dead '#'.