### PR TITLE
feat(scheduler): record run outcomes for the remaining four jobs

### DIFF
--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -47,21 +47,6 @@ def _run_async(coro):  # type: ignore[no-untyped-def]
         loop.close()
 
 
-def _run_job(label: str, coro) -> None:  # type: ignore[no-untyped-def]
-    """Run a pipeline coroutine, translating its outcome into a log line.
-
-    A ``PipelineSkip`` is a deliberate no-op and logged at info level. Every
-    other exception is a real failure and logged at error level. This is the
-    skip-versus-failure boundary the rest of the pipeline keys on.
-    """
-    try:
-        _run_async(coro)
-    except PipelineSkip as e:
-        logger.info("Scheduler: %s skipped — %s", label, e)
-    except Exception:
-        logger.exception("Scheduler: %s failed", label)
-
-
 async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-def]
     """Run a job body, timing it and recording its outcome durably.
 
@@ -142,7 +127,7 @@ def job_garmin_sync() -> None:
     Fetches the last 2 days of data to handle timezone edge cases and overnight sync.
     """
     logger.info("Scheduler: starting Garmin sync")
-    _run_job("Garmin sync", _garmin_sync())
+    _run_recorded_job("garmin_sync", _garmin_sync())
 
 
 async def _garmin_sync() -> None:
@@ -186,7 +171,7 @@ async def _daily_briefing() -> None:
 def job_weekly_plan() -> None:
     """Generate the weekly training plan (runs Sunday evening for next week)."""
     logger.info("Scheduler: generating weekly plan")
-    _run_job("weekly plan", _weekly_plan())
+    _run_recorded_job("weekly_plan", _weekly_plan())
 
 
 async def _weekly_plan() -> None:
@@ -230,7 +215,7 @@ async def _weekly_plan() -> None:
 def job_weekly_recap() -> None:
     """Generate the weekly recap (runs Monday morning for the previous week)."""
     logger.info("Scheduler: generating weekly recap")
-    _run_job("weekly recap", _weekly_recap())
+    _run_recorded_job("weekly_recap", _weekly_recap())
 
 
 async def _weekly_recap() -> None:
@@ -255,7 +240,7 @@ def job_post_workout_analysis() -> None:
     an existing CoachingInsight, generates analysis for each, and sends email.
     """
     logger.info("Scheduler: starting post-workout analysis scan")
-    _run_job("post-workout analysis", _post_workout_analysis())
+    _run_recorded_job("post_workout_analysis", _post_workout_analysis())
 
 
 async def _post_workout_analysis() -> None:
@@ -291,6 +276,10 @@ async def _post_workout_analysis() -> None:
         logger.info("Scheduler: found %d activities to analyze", len(activities))
         send_email = await _get_user_email_pref("email_post_workout")
 
+        analysed = 0
+        skipped = 0
+        failures: list[str] = []
+
         for activity in activities:
             # Per-activity resilience: one activity's skip or failure must not
             # abort the batch. A whole-batch skip (no activities) is raised above.
@@ -310,13 +299,48 @@ async def _post_workout_analysis() -> None:
                     logger.info(
                         "Scheduler: post-workout email sent for activity %d", activity.id
                     )
+                # Tallied last so an activity counts exactly once: a failure
+                # anywhere above (including the email send) lands in ``failures``
+                # instead, keeping the totals in the error message honest.
+                analysed += 1
             except PipelineSkip as e:
+                skipped += 1
                 logger.info(
                     "Scheduler: post-workout analysis skipped for activity %d — %s",
                     activity.id,
                     e,
                 )
-            except Exception:
+            except Exception as e:  # noqa: BLE001 - tallied, then reported once below
+                failures.append(f"activity {activity.id}: {e}")
                 logger.exception(
                     "Scheduler: post-workout analysis failed for activity %d", activity.id
                 )
+
+    _raise_post_workout_outcome(analysed, skipped, failures)
+
+
+def _raise_post_workout_outcome(analysed: int, skipped: int, failures: list[str]) -> None:
+    """Collapse the per-activity outcomes into the run's single outcome.
+
+    Called once, after the whole batch, so the run records one coherent result
+    rather than one per activity. The recording helper reads the outcome off
+    this call: returning normally records ``success``, raising ``PipelineSkip``
+    records ``skipped``, and raising anything else records ``failed`` with the
+    message as the error detail.
+
+    ``analysed`` counts activities that produced an insight, ``skipped`` those
+    that already had one, and ``failures`` holds one message per activity that
+    blew up. The empty-batch case never reaches here — it is raised as a skip
+    before the loop.
+    """
+    total = analysed + skipped + len(failures)
+    if failures:
+        # A partial failure is still a failure: the run is the only durable
+        # signal, so a nightly batch quietly losing one activity must not be
+        # filed as a success.
+        raise RuntimeError(
+            f"{len(failures)} of {total} activities failed — " + "; ".join(failures)
+        )
+    if analysed == 0:
+        # Everything already had an insight — deliberate no-op, not work done.
+        raise PipelineSkip(f"all {skipped} activities already analysed")

--- a/tests/test_scheduler/test_job_runs.py
+++ b/tests/test_scheduler/test_job_runs.py
@@ -5,14 +5,24 @@ Drive a job body through the recording helper and assert on the persisted
 """
 
 import logging
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import select
 
 from mycoach.coaching.exceptions import PipelineSkip
+from mycoach.models.activity import Activity
 from mycoach.models.job_run import JobRun
-from mycoach.scheduler.jobs import _daily_briefing, _record_run
+from mycoach.scheduler.jobs import (
+    USER_ID,
+    _daily_briefing,
+    _garmin_sync,
+    _post_workout_analysis,
+    _record_run,
+    _weekly_plan,
+    _weekly_recap,
+)
 from tests.conftest import test_session
 
 
@@ -160,3 +170,288 @@ async def test_daily_briefing_body_records_failure() -> None:
     assert len(runs) == 1
     assert runs[0].status == "failed"
     assert runs[0].error == "Gemini call failed"
+
+
+def _mock_garmin_source() -> MagicMock:
+    source = MagicMock()
+    source.authenticate = AsyncMock(return_value=True)
+    source.fetch_and_import = AsyncMock(
+        return_value=MagicMock(health_snapshots_created=2, activities_created=1)
+    )
+    return source
+
+
+async def test_garmin_sync_body_records_run() -> None:
+    """A completed Garmin sync records one success row."""
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=_mock_garmin_source()),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch(
+            "mycoach.scheduler.jobs.merge_garmin_hevy",
+            AsyncMock(return_value=MagicMock(merged=0)),
+        ),
+    ):
+        await _record_run("garmin_sync", _garmin_sync())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].job_name == "garmin_sync"
+    assert runs[0].status == "success"
+
+
+async def test_garmin_auth_failure_records_failed_run() -> None:
+    """Credential expiry is a recorded failure, not a silent return.
+
+    Sync, briefing, and post-workout analysis all sit downstream of this, so an
+    unrecorded auth failure would halt the daily pipeline with no signal at all.
+    """
+    source = _mock_garmin_source()
+    source.authenticate = AsyncMock(return_value=False)
+
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=source),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+    ):
+        await _record_run("garmin_sync", _garmin_sync())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].error == "Garmin authentication failed"
+    source.fetch_and_import.assert_not_awaited()
+
+
+async def test_weekly_plan_body_records_run() -> None:
+    """A generated weekly plan records one success row."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_plan = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _record_run("weekly_plan", _weekly_plan())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].job_name == "weekly_plan"
+    assert runs[0].status == "success"
+
+
+async def test_weekly_plan_body_records_skip() -> None:
+    """An existing active plan records a skip, leaving idempotency untouched."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_plan = AsyncMock(
+        side_effect=PipelineSkip("Active plan already exists")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+    ):
+        await _record_run("weekly_plan", _weekly_plan())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "skipped"
+    assert runs[0].error is None
+
+
+async def test_weekly_plan_body_records_failure() -> None:
+    """A generation failure records a failed run with the cause."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_plan = AsyncMock(side_effect=RuntimeError("bad JSON"))
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+    ):
+        await _record_run("weekly_plan", _weekly_plan())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].error == "bad JSON"
+
+
+async def test_weekly_recap_body_records_run() -> None:
+    """A generated weekly recap records one success row."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_recap = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _record_run("weekly_recap", _weekly_recap())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].job_name == "weekly_recap"
+    assert runs[0].status == "success"
+
+
+async def test_weekly_recap_body_records_skip() -> None:
+    """An existing recap records a skip, leaving idempotency untouched."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_recap = AsyncMock(
+        side_effect=PipelineSkip("Weekly recap already exists")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+    ):
+        await _record_run("weekly_recap", _weekly_recap())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "skipped"
+
+
+async def test_weekly_recap_body_records_failure() -> None:
+    """A generation failure records a failed run with the cause."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_recap = AsyncMock(side_effect=RuntimeError("bad JSON"))
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+    ):
+        await _record_run("weekly_recap", _weekly_recap())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].error == "bad JSON"
+
+
+async def _add_activities(count: int) -> None:
+    """Persist unanalysed activities inside the post-workout scan window."""
+    async with test_session() as session:
+        for i in range(count):
+            session.add(
+                Activity(
+                    user_id=USER_ID,
+                    sport="swimming",
+                    title=f"Session {i}",
+                    start_time=datetime.utcnow(),
+                    data_source="garmin",
+                )
+            )
+        await session.commit()
+
+
+async def test_post_workout_body_records_single_success_for_whole_batch() -> None:
+    """Several activities in one execution still record exactly one run."""
+    await _add_activities(2)
+    mock_engine = MagicMock()
+    mock_engine.generate_post_workout_analysis = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _record_run("post_workout_analysis", _post_workout_analysis())
+
+    runs = await _job_runs()
+    assert len(runs) == 1  # one row for the run, not one per activity
+    assert runs[0].job_name == "post_workout_analysis"
+    assert runs[0].status == "success"
+    assert mock_engine.generate_post_workout_analysis.await_count == 2
+
+
+async def test_post_workout_body_records_skip_when_nothing_to_analyse() -> None:
+    """An empty scan records a skip — no activities is not a failure."""
+    mock_engine = MagicMock()
+    mock_engine.generate_post_workout_analysis = AsyncMock()
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+    ):
+        await _record_run("post_workout_analysis", _post_workout_analysis())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "skipped"
+    mock_engine.generate_post_workout_analysis.assert_not_awaited()
+
+
+async def test_post_workout_body_records_partial_failure_as_one_failed_run() -> None:
+    """One activity failing out of two fails the run, and only the run."""
+    await _add_activities(2)
+    mock_engine = MagicMock()
+    mock_engine.generate_post_workout_analysis = AsyncMock(
+        side_effect=[RuntimeError("bad JSON"), MagicMock()]
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _record_run("post_workout_analysis", _post_workout_analysis())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].error is not None
+    assert "1 of 2 activities failed" in runs[0].error
+    assert "bad JSON" in runs[0].error
+    # The surviving activity was still analysed — resilience is unchanged.
+    assert mock_engine.generate_post_workout_analysis.await_count == 2
+
+
+async def test_post_workout_body_records_skip_when_all_already_analysed() -> None:
+    """A batch where every activity already had an insight persists as skipped."""
+    await _add_activities(2)
+    mock_engine = MagicMock()
+    mock_engine.generate_post_workout_analysis = AsyncMock(
+        side_effect=PipelineSkip("Post-workout analysis already exists")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _record_run("post_workout_analysis", _post_workout_analysis())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "skipped"
+    assert runs[0].error is None
+
+
+async def test_post_workout_failed_email_counts_the_activity_once() -> None:
+    """An activity whose email send fails is a failure, not both a success and one.
+
+    The tally feeds the run's only durable error detail, so an activity counted
+    twice would persist a wrong denominator ("1 of 2" for a single activity).
+    """
+    await _add_activities(1)
+    mock_engine = MagicMock()
+    mock_engine.generate_post_workout_analysis = AsyncMock(
+        return_value=MagicMock(content='{"performance_summary": "ok"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch(
+            "mycoach.scheduler.jobs.send_post_workout",
+            side_effect=RuntimeError("SMTP down"),
+        ),
+    ):
+        await _record_run("post_workout_analysis", _post_workout_analysis())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].error is not None
+    assert "1 of 1 activities failed" in runs[0].error

--- a/tests/test_scheduler/test_jobs.py
+++ b/tests/test_scheduler/test_jobs.py
@@ -75,19 +75,22 @@ async def test_garmin_sync_auth_failure_raises(mock_session: AsyncMock) -> None:
     mock_source.fetch_and_import.assert_not_awaited()
 
 
-def test_garmin_sync_job_logs_auth_failure(caplog: pytest.LogCaptureFixture) -> None:
+def test_garmin_sync_job_logs_auth_failure(
+    mock_session: AsyncMock, caplog: pytest.LogCaptureFixture
+) -> None:
     """The Garmin job wrapper surfaces an auth failure at error level, not silently."""
     mock_source = MagicMock()
     mock_source.authenticate = AsyncMock(return_value=False)
 
     with (
         patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         caplog.at_level(logging.INFO),
     ):
         job_garmin_sync()  # must not raise
 
     assert any(
-        r.levelno == logging.ERROR and "Garmin sync failed" in r.message
+        r.levelno == logging.ERROR and "garmin_sync failed" in r.message
         for r in caplog.records
     )
 
@@ -243,7 +246,7 @@ def test_weekly_plan_job_logs_skip(
         mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
         job_weekly_plan()  # must not raise
 
-    skip_logs = [r for r in caplog.records if "weekly plan skipped" in r.message]
+    skip_logs = [r for r in caplog.records if "weekly_plan skipped" in r.message]
     assert skip_logs and all(r.levelno == logging.INFO for r in skip_logs)
     assert not any(r.levelno >= logging.ERROR for r in caplog.records)
 
@@ -267,7 +270,7 @@ def test_weekly_plan_job_logs_failure(
         job_weekly_plan()  # must not raise
 
     assert any(
-        r.levelno == logging.ERROR and "weekly plan failed" in r.message
+        r.levelno == logging.ERROR and "weekly_plan failed" in r.message
         for r in caplog.records
     )
     assert not any("skipped" in r.message for r in caplog.records)
@@ -332,7 +335,7 @@ def test_weekly_recap_job_logs_failure(
         job_weekly_recap()  # must not raise
 
     assert any(
-        r.levelno == logging.ERROR and "weekly recap failed" in r.message
+        r.levelno == logging.ERROR and "weekly_recap failed" in r.message
         for r in caplog.records
     )
     assert not any("skipped" in r.message for r in caplog.records)
@@ -415,7 +418,11 @@ async def test_post_workout_analysis_skips_existing_per_activity(
 async def test_post_workout_analysis_failure_does_not_abort_batch(
     mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A per-activity failure is logged at error level and the batch continues."""
+    """A per-activity failure is logged, the batch continues, and the run still fails.
+
+    Continuing the batch is resilience, not absolution: the surviving activity is
+    analysed, then the coroutine raises so the run is recorded as a failure.
+    """
     mock_activity_1 = MagicMock(id=10, title="Morning Swim")
     mock_activity_2 = MagicMock(id=11, title="Gym Session")
     mock_engine.generate_post_workout_analysis = AsyncMock(
@@ -434,6 +441,7 @@ async def test_post_workout_analysis_failure_does_not_abort_batch(
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
         caplog.at_level(logging.INFO),
+        pytest.raises(RuntimeError, match="1 of 2 activities failed"),
     ):
         await _post_workout_analysis()
 
@@ -442,6 +450,33 @@ async def test_post_workout_analysis_failure_does_not_abort_batch(
         r.levelno == logging.ERROR and "post-workout analysis failed for activity 10" in r.message
         for r in caplog.records
     )
+
+
+async def test_post_workout_analysis_all_skipped_raises_skip(
+    mock_session: AsyncMock, mock_engine: MagicMock,
+) -> None:
+    """A batch where every activity already had an insight is a skip, not a success."""
+    mock_engine.generate_post_workout_analysis = AsyncMock(
+        side_effect=[
+            PipelineSkip("Post-workout analysis already exists for activity 10"),
+            PipelineSkip("Post-workout analysis already exists for activity 11"),
+        ]
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [
+        MagicMock(id=10, title="Morning Swim"),
+        MagicMock(id=11, title="Gym Session"),
+    ]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        pytest.raises(PipelineSkip, match="all 2 activities already analysed"),
+    ):
+        await _post_workout_analysis()
 
 
 async def test_post_workout_analysis_sends_email(


### PR DESCRIPTION
Extend durable run recording from the daily-briefing tracer bullet to the whole scheduled pipeline. With all five jobs covered, an empty run history can finally be read as "nothing ran" rather than "something ran and left no trace".

- Route garmin_sync, weekly_plan, weekly_recap, and post_workout_analysis through _run_recorded_job, under snake_case job_name keys so log aggregation groups on the same identifiers the column stores.
- Retire _run_job: with every job recorded, a second log-only wrapper is exactly how a pipeline drifts back into being half-instrumented.
- Collapse the post-workout batch into one coherent run outcome via _raise_post_workout_outcome. Per-activity resilience is unchanged — one activity's failure still doesn't abort the batch — but the run itself now fails when any activity did, carrying "N of M activities failed" plus the per-activity detail. A batch where every activity already had an insight is a skip, not a success. Each activity is tallied exactly once, counted only after its email send, so a failed send can't inflate the denominator.
- Garmin auth failure was already raising rather than returning silently; it now lands as a failed run with the cause captured, so credential expiry can no longer halt the daily pipeline in silence.
- Idempotency is untouched throughout: it still comes from the existing-insight check, never from run history.

Closes #8