### PR TITLE
feat(scheduler): surface email delivery outcome on job runs

### DIFF
--- a/alembic/versions/f6a7b8c9d0e1_add_email_delivered_to_job_runs.py
+++ b/alembic/versions/f6a7b8c9d0e1_add_email_delivered_to_job_runs.py
@@ -1,0 +1,39 @@
+"""add email_delivered to job_runs
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-07-27 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6a7b8c9d0e1'
+down_revision: Union[str, Sequence[str], None] = 'e5f6a7b8c9d0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Existing rows predate delivery recording, so nothing is known to have been
+    # delivered against them — false is both the correct backfill and the default
+    # for any run that sends no email.
+    op.add_column(
+        'job_runs',
+        sa.Column(
+            'email_delivered',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('job_runs', 'email_delivered')

--- a/src/mycoach/email/sender.py
+++ b/src/mycoach/email/sender.py
@@ -30,11 +30,6 @@ def _render_template(template_name: str, context: dict) -> str:  # type: ignore[
     return template.render(**context)
 
 
-<<<<<<< Updated upstream
-=======
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
 # Display label/unit for each DailyBriefingKeyMetrics field, in the order
 # emails should show them. Keys absent or None are skipped.
 _KEY_METRICS_DISPLAY: dict[str, tuple[str, str]] = {
@@ -46,25 +41,16 @@ _KEY_METRICS_DISPLAY: dict[str, tuple[str, str]] = {
 }
 
 
-<<<<<<< Updated upstream
-def _format_key_metrics(key_metrics: dict) -> list[dict]:  # type: ignore[type-arg]
-    """Turn the raw DailyBriefingKeyMetrics fields into display-ready rows."""
-    rows = []
-=======
 def _format_key_metrics(key_metrics: dict) -> dict[str, str]:  # type: ignore[type-arg]
     """Turn the raw DailyBriefingKeyMetrics fields into label -> display value.
 
     Insertion order follows _KEY_METRICS_DISPLAY, which is the order emails show.
     """
     rows: dict[str, str] = {}
->>>>>>> Stashed changes
     for key, (label, unit) in _KEY_METRICS_DISPLAY.items():
         value = key_metrics.get(key)
         if value is None:
             continue
-<<<<<<< Updated upstream
-        rows.append({"label": label, "value": value, "unit": unit})
-=======
         rows[label] = f"{value} {unit}" if unit else str(value)
     return rows
 
@@ -129,7 +115,6 @@ def _format_session_details(details: dict | None) -> dict[str, str]:  # type: ig
         row = _format_cardio_detail(key, value)
         if row is not None:
             rows[row[0]] = row[1]
->>>>>>> Stashed changes
     return rows
 
 
@@ -138,10 +123,6 @@ def _dashboard_url(settings: Settings) -> str:
     return f"{settings.app_base_url}/dashboard"
 
 
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 def _send_via_resend(settings: Settings, to: str, subject: str, html: str) -> bool:
     """Send email using Resend API."""
     resend.api_key = settings.email_resend_api_key
@@ -231,25 +212,12 @@ def send_weekly_plan(
     ]
     html = _render_template(
         "weekly_plan.html",
-<<<<<<< Updated upstream
-        {
-            "summary": summary,
-            "sessions": sessions,
-            "week_start": week_start,
-            "dashboard_url": _dashboard_url(settings),
-        },
-=======
-<<<<<<< Updated upstream
-        {"summary": summary, "sessions": sessions, "week_start": week_start},
-=======
         {
             "summary": summary,
             "sessions": display_sessions,
             "week_start": week_start,
             "dashboard_url": _dashboard_url(settings),
         },
->>>>>>> Stashed changes
->>>>>>> Stashed changes
     )
     return send_email(settings.email_to, "MyCoach — Weekly Plan", html, settings)
 

--- a/src/mycoach/email/templates/base.html
+++ b/src/mycoach/email/templates/base.html
@@ -10,118 +10,6 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
 <style>
-<<<<<<< Updated upstream
-  :root { color-scheme: light dark; supported-color-schemes: light dark; }
-  body { margin:0; padding:0; background:#f0efec; -webkit-font-smoothing:antialiased; -webkit-text-size-adjust:100%; }
-  table { border-collapse:collapse; }
-  img { border:0; line-height:100%; }
-  a { text-decoration:none; }
-
-  .wrap { width:100%; background:#f0efec; padding:26px 0; }
-  .email { max-width:420px; margin:0 auto; background:#ffffff; border:1px solid rgba(0,0,0,.08); border-radius:16px; overflow:hidden; }
-  .px { padding-left:24px; padding-right:24px; }
-
-  .hd-b { border-bottom:1px solid rgba(0,0,0,.08); }
-  .dot { display:inline-block; width:9px; height:9px; border-radius:3px; background:#ea6d1f; vertical-align:middle; margin-right:9px; }
-  .brand { font:700 15px 'IBM Plex Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; color:#18191b; vertical-align:middle; }
-  .hd-meta { font:400 11px 'IBM Plex Mono',ui-monospace,Menlo,monospace; color:#78716c; }
-
-  .eyebrow { font:600 11px 'IBM Plex Sans',sans-serif; letter-spacing:.16em; text-transform:uppercase; color:#78716c; }
-  .sec { font:600 11px 'IBM Plex Sans',sans-serif; letter-spacing:.14em; text-transform:uppercase; color:#78716c; }
-  .verdict { font:700 46px/1 'IBM Plex Sans',-apple-system,sans-serif; letter-spacing:-.02em; color:#18191b; }
-  .rule { width:120px; height:5px; border-radius:3px; background:#ea6d1f; font-size:0; line-height:0; }
-  .lead { font:400 15px/1.55 'IBM Plex Sans',sans-serif; color:#52525b; }
-  .p { font:400 14px/1.7 'IBM Plex Sans',sans-serif; color:#3f3f46; }
-  .strong { color:#18191b; font-weight:600; }
-
-  .block-b { border-top:1px solid rgba(0,0,0,.08); }
-  .mrow { border-bottom:1px solid rgba(0,0,0,.06); }
-  .mlabel { font:500 13px 'IBM Plex Sans',sans-serif; color:#3f3f46; }
-  .msub { font:400 11px 'IBM Plex Mono',monospace; color:#a1a1aa; }
-  .mval { font:600 17px 'IBM Plex Mono',ui-monospace,Menlo,monospace; color:#18191b; text-align:right; white-space:nowrap; }
-  .munit { font-size:12px; color:#a1a1aa; }
-
-  .coach { background:rgba(234,109,31,.07); border:1px solid rgba(234,109,31,.28); border-radius:10px; }
-  .coach-k { font:600 11px 'IBM Plex Sans',sans-serif; letter-spacing:.08em; text-transform:uppercase; color:#c2560f; }
-  .coach-t { font:400 14px/1.55 'IBM Plex Sans',sans-serif; color:#7c4a26; }
-
-  .li { font:400 14px/1.5 'IBM Plex Sans',sans-serif; color:#3f3f46; }
-  .mk-plus { font:600 14px 'IBM Plex Mono',monospace; color:#c2560f; }
-  .mk-arrow { font:600 14px 'IBM Plex Mono',monospace; color:#9ca3af; }
-
-  .badge { display:inline-block; font:600 11px 'IBM Plex Sans',sans-serif; letter-spacing:.03em; padding:4px 10px; border-radius:999px; }
-  .b-amber { background:rgba(234,109,31,.10); color:#c2560f; }
-  .b-emerald { background:rgba(5,150,105,.12); color:#047857; }
-  .b-sky { background:rgba(2,132,199,.12); color:#0369a1; }
-  .b-zinc { background:rgba(0,0,0,.06); color:#52525b; }
-
-  .cta { display:block; text-align:center; font:700 15px 'IBM Plex Sans',sans-serif; color:#ffffff !important; background:#ea6d1f; padding:15px 0; border-radius:12px; }
-
-  .ft { border-top:1px solid rgba(0,0,0,.08); background:#faf9f7; }
-  .ft-t { font:400 12px/1.6 'IBM Plex Sans',sans-serif; color:#a1a1aa; }
-  .ft-t a { color:#78716c; }
-
-  @media (prefers-color-scheme: dark) {
-    body, .wrap { background:#08090a !important; }
-    .email { background:#0b0c0e !important; border-color:rgba(255,255,255,.08) !important; }
-    .hd-b, .block-b, .ft { border-color:rgba(255,255,255,.08) !important; }
-    .ft { background:#0a0b0c !important; }
-    .brand, .verdict, .strong, .mval { color:#fafafa !important; }
-    .hd-meta, .eyebrow, .sec, .mk-arrow, .msub, .munit { color:#6b7280 !important; }
-    .lead, .mlabel { color:#a1a1aa !important; }
-    .p, .li { color:#c9c9cd !important; }
-    .rule { background:#fb923c !important; }
-    .coach { background:rgba(251,146,60,.09) !important; border-color:rgba(251,146,60,.22) !important; }
-    .coach-k, .mk-plus { color:#fb923c !important; }
-    .coach-t { color:#e4c9ac !important; }
-    .mrow { border-color:rgba(255,255,255,.06) !important; }
-    .b-amber { background:rgba(251,146,60,.13) !important; color:#fdba74 !important; }
-    .b-emerald { background:rgba(16,185,129,.15) !important; color:#6ee7b7 !important; }
-    .b-sky { background:rgba(56,189,248,.15) !important; color:#7dd3fc !important; }
-    .b-zinc { background:rgba(255,255,255,.08) !important; color:#a1a1aa !important; }
-    .cta { background:#fb923c !important; color:#0a0b0d !important; }
-    .ft-t { color:#57575c !important; }
-    .ft-t a { color:#78716c !important; }
-  }
-</style>
-</head>
-<body>
-=======
-<<<<<<< Updated upstream
-  body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f3f4f6; color: #1f2937; }
-  .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
-  .header { background-color: #1e40af; color: #ffffff; padding: 20px 24px; }
-  .header h1 { margin: 0; font-size: 20px; font-weight: 700; }
-  .header p { margin: 4px 0 0; font-size: 13px; color: #bfdbfe; }
-  .content { padding: 24px; }
-  .footer { padding: 16px 24px; text-align: center; font-size: 12px; color: #9ca3af; border-top: 1px solid #e5e7eb; }
-  .card { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
-  .card h3 { margin: 0 0 8px; font-size: 15px; color: #1e40af; }
-  .badge { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 12px; font-weight: 600; }
-  .badge-green { background: #dcfce7; color: #166534; }
-  .badge-yellow { background: #fef9c3; color: #854d0e; }
-  .badge-red { background: #fee2e2; color: #991b1b; }
-  .badge-blue { background: #dbeafe; color: #1e40af; }
-  .metric { display: inline-block; text-align: center; padding: 8px 12px; }
-  .metric-value { font-size: 20px; font-weight: 700; color: #111827; }
-  .metric-label { font-size: 11px; color: #6b7280; text-transform: uppercase; }
-  ul { padding-left: 20px; }
-  li { margin-bottom: 4px; }
-</style>
-</head>
-<body>
-<div class="container">
-  <div class="header">
-    <h1>MyCoach</h1>
-    <p>{% block subtitle %}{% endblock %}</p>
-  </div>
-  <div class="content">
-    {% block content %}{% endblock %}
-  </div>
-  <div class="footer">
-    MyCoach &mdash; AI-powered personal fitness coaching
-  </div>
-=======
   :root { color-scheme: light dark; supported-color-schemes: light dark; }
   body { margin:0; padding:0; background:#ffffff; -webkit-font-smoothing:antialiased; -webkit-text-size-adjust:100%; }
   table { border-collapse:collapse; }
@@ -196,7 +84,6 @@
 </style>
 </head>
 <body>
->>>>>>> Stashed changes
 <div class="wrap">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
     <tr>
@@ -221,10 +108,6 @@
           <tr>
             <td class="ft px" style="padding-top:18px;padding-bottom:22px;">
               <div class="ft-t">MyCoach &mdash; AI-powered personal fitness coaching.</div>
-<<<<<<< Updated upstream
-              <div class="ft-t" style="margin-top:6px;"><a href="{{ manage_url|default('#') }}">Manage emails</a> &middot; <a href="{{ unsubscribe_url|default('#') }}">Unsubscribe</a></div>
-=======
->>>>>>> Stashed changes
             </td>
           </tr>
 
@@ -232,10 +115,6 @@
       </td>
     </tr>
   </table>
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 </div>
 </body>
 </html>

--- a/src/mycoach/email/templates/daily_briefing.html
+++ b/src/mycoach/email/templates/daily_briefing.html
@@ -4,15 +4,6 @@
 {% block content %}
 {% set _vmap = {'go_hard': 'Go Hard', 'moderate': 'Moderate', 'active_recovery': 'Active Recovery', 'rest': 'Rest'} %}
 
-<<<<<<< Updated upstream
-=======
-<<<<<<< Updated upstream
-<div class="card">
-  <h3>Sleep Assessment</h3>
-  <p>{{ briefing.sleep_assessment }}</p>
-</div>
-=======
->>>>>>> Stashed changes
 <!-- Hero: readiness verdict -->
 <tr>
   <td class="px" style="padding-top:26px;padding-bottom:20px;">
@@ -22,13 +13,6 @@
     {% if briefing.recovery_status %}
     <div class="lead" style="margin-top:14px;">{{ briefing.recovery_status }}</div>
     {% endif %}
-<<<<<<< Updated upstream
-    {% if briefing.readiness_explanation %}
-    <div class="lead" style="margin-top:10px;">{{ briefing.readiness_explanation }}</div>
-    {% endif %}
-  </td>
-</tr>
-=======
   </td>
 </tr>
 
@@ -41,41 +25,6 @@
       <tr>
         <td class="mrow mlabel" style="padding:12px 0;">{{ key }}</td>
         <td class="mrow mval" style="padding:12px 0;">{{ value }}</td>
-      </tr>
-      {% endfor %}
-    </table>
-  </td>
-</tr>
-{% endif %}
-
-{% if briefing.sleep_assessment %}
-<!-- Sleep assessment -->
-<tr>
-  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
-    <div class="sec" style="margin-bottom:8px;">Sleep assessment</div>
-    <div class="p">{{ briefing.sleep_assessment }}</div>
-  </td>
-</tr>
-{% endif %}
->>>>>>> Stashed changes
-
-{% if briefing.workout_adjustments %}
-<div class="card">
-  <h3>Workout Adjustments</h3>
-  <p>{{ briefing.workout_adjustments }}</p>
-</div>
-{% endif %}
->>>>>>> Stashed changes
-
-{% if briefing.key_metrics %}
-<!-- Key metrics -->
-<tr>
-  <td class="px" style="padding-top:6px;padding-bottom:6px;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-top:1px solid rgba(0,0,0,.08);">
-      {% for metric in briefing.key_metrics %}
-      <tr>
-        <td class="mrow mlabel" style="padding:12px 0;">{{ metric.label }}</td>
-        <td class="mrow mval" style="padding:12px 0;">{{ metric.value }}{% if metric.unit %} <span class="munit">{{ metric.unit }}</span>{% endif %}</td>
       </tr>
       {% endfor %}
     </table>

--- a/src/mycoach/email/templates/weekly_plan.html
+++ b/src/mycoach/email/templates/weekly_plan.html
@@ -18,26 +18,6 @@
 
 <!-- Sessions -->
 {% for session in sessions %}
-<<<<<<< Updated upstream
-=======
-<<<<<<< Updated upstream
-<div class="card">
-  <h3>{{ session.day_name }} &mdash; {{ session.title }}</h3>
-  <p>
-    <span class="badge badge-blue">{{ session.sport }}</span>
-    {% if session.duration_minutes %} &bull; {{ session.duration_minutes }} min{% endif %}
-  </p>
-  {% if session.notes %}<p>{{ session.notes }}</p>{% endif %}
-  {% if session.details %}
-  <ul>
-  {% for key, value in session.details.items() %}
-    <li><strong>{{ key }}:</strong> {{ value }}</li>
-  {% endfor %}
-  </ul>
-  {% endif %}
-</div>
-=======
->>>>>>> Stashed changes
 <tr>
   <td class="px block-b" style="padding-top:18px;padding-bottom:18px;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
@@ -57,31 +37,18 @@
     {% if session.notes %}
     <div class="p" style="margin-top:8px;">{{ session.notes }}</div>
     {% endif %}
-<<<<<<< Updated upstream
-    {% if session.details and session.details.exercises %}
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:10px;">
-      {% for ex in session.details.exercises %}
-      <tr>
-        <td class="mlabel" style="padding:6px 0;font-weight:400;color:#78716c;">{{ ex.name }}</td>
-        <td class="mval" style="padding:6px 0;font-size:13px;">{{ ex.sets }}&times;{{ ex.reps }}{% if ex.target_weight_kg %} @ {{ ex.target_weight_kg }}kg{% endif %}{% if ex.rpe %} &middot; RPE {{ ex.rpe }}{% endif %}</td>
-=======
     {% if session.details %}
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:10px;">
       {% for key, value in session.details.items() %}
       <tr>
         <td class="mlabel" style="padding:6px 0;font-weight:400;color:#78716c;">{{ key }}</td>
         <td class="mval" style="padding:6px 0;font-size:13px;">{{ value }}</td>
->>>>>>> Stashed changes
       </tr>
       {% endfor %}
     </table>
     {% endif %}
   </td>
 </tr>
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 {% endfor %}
 
 <tr>

--- a/src/mycoach/email/templates/weekly_recap.html
+++ b/src/mycoach/email/templates/weekly_recap.html
@@ -93,7 +93,6 @@
   </td>
 </tr>
 {% endif %}
-<<<<<<< Updated upstream
 
 {% if recap.coach_recommendations %}
 <tr>
@@ -110,18 +109,10 @@
   </td>
 </tr>
 {% endif %}
-=======
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
 
 <tr>
   <td class="px" style="padding-top:24px;padding-bottom:28px;">
     <a href="{{ dashboard_url|default('#') }}" class="cta">See full recap &rarr;</a>
   </td>
 </tr>
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 {% endblock %}

--- a/src/mycoach/logging_config.py
+++ b/src/mycoach/logging_config.py
@@ -32,6 +32,7 @@ class JSONFormatter(logging.Formatter):
             "job_name",
             "job_status",
             "job_error",
+            "email_delivered",
         ):
             value = getattr(record, key, None)
             if value is not None:

--- a/src/mycoach/models/job_run.py
+++ b/src/mycoach/models/job_run.py
@@ -22,3 +22,10 @@ class JobRun(Base):
     duration_ms: Mapped[int]
     status: Mapped[str] = mapped_column(String(20))  # success, skipped, failed
     error: Mapped[str | None] = mapped_column(Text, default=None)
+    # Whether an email actually went out, kept deliberately separate from status
+    # rather than folded into it. A run whose insight generated fine but whose
+    # recipient has that email type switched off is a genuine success that sent
+    # nothing; a run whose send was attempted and rejected is a failure. Keeping
+    # delivery its own field represents both without overloading the status
+    # vocabulary, and lets monitoring alert on "succeeding but not delivering".
+    email_delivered: Mapped[bool] = mapped_column(default=False)

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -78,18 +78,23 @@ _current_delivery: ContextVar[_Delivery | None] = ContextVar(
 )
 
 
-def _deliver(send: Callable[[], bool], description: str) -> None:
+def _deliver(send: Callable[[], bool], email_label: str) -> None:
     """Attempt one email send, recording the outcome and failing on rejection.
 
     ``send`` is the zero-argument send call. A False return means the backend
     refused the message, which is a real failure rather than something to log
     over; a True return is noted on the run as delivery having happened.
+
+    The "email sent" log line lives here rather than at the call sites so it can
+    only ever follow a send that actually reported success — the bug this helper
+    exists to prevent was exactly that line being logged unconditionally.
     """
     if not send():
-        raise EmailDeliveryError(f"{description} email send failed")
+        raise EmailDeliveryError(f"{email_label} email send failed")
     delivery = _current_delivery.get()
     if delivery is not None:
         delivery.delivered = True
+    logger.info("Scheduler: %s email sent", email_label)
 
 
 async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-def]
@@ -219,7 +224,6 @@ async def _daily_briefing() -> None:
         if await _get_user_email_pref("email_daily_briefing"):
             content = json.loads(insight.content)
             _deliver(partial(send_daily_briefing, content), "daily briefing")
-            logger.info("Scheduler: daily briefing email sent")
 
 
 
@@ -268,7 +272,6 @@ async def _weekly_plan() -> None:
                 ),
                 "weekly plan",
             )
-            logger.info("Scheduler: weekly plan email sent")
 
 
 def job_weekly_recap() -> None:
@@ -292,7 +295,6 @@ async def _weekly_recap() -> None:
                 partial(send_weekly_recap, content, week_start=str(last_monday)),
                 "weekly recap",
             )
-            logger.info("Scheduler: weekly recap email sent")
 
 
 def job_post_workout_analysis() -> None:
@@ -363,9 +365,6 @@ async def _post_workout_analysis() -> None:
                     _deliver(
                         partial(send_post_workout, content, activity.title),
                         f"post-workout activity {activity.id}",
-                    )
-                    logger.info(
-                        "Scheduler: post-workout email sent for activity %d", activity.id
                     )
                 # Tallied last so an activity counts exactly once: a failure
                 # anywhere above (including the email send) lands in ``failures``

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -9,7 +9,11 @@ import asyncio
 import json
 import logging
 import time
+from collections.abc import Callable
+from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
+from functools import partial
 
 from sqlalchemy import select
 
@@ -47,21 +51,68 @@ def _run_async(coro):  # type: ignore[no-untyped-def]
         loop.close()
 
 
+class EmailDeliveryError(RuntimeError):
+    """An email send was attempted and rejected by the backend.
+
+    Raised by ``_deliver`` so a rejected send reaches ``_record_run`` as an
+    ordinary failure. The send functions signal rejection by returning False,
+    which jobs previously discarded — logging "email sent" for a send that never
+    happened.
+    """
+
+
+@dataclass
+class _Delivery:
+    """Per-run tally of whether any email actually went out."""
+
+    delivered: bool = False
+
+
+# Set by ``_record_run`` for the duration of one job body, so ``_deliver`` can
+# note a successful send from wherever in the body it happens without every job
+# threading the fact back through both its return value and its exceptions. That
+# matters for the post-workout batch, which can deliver one email and still fail
+# the run on another — the exception would otherwise lose the delivery.
+_current_delivery: ContextVar[_Delivery | None] = ContextVar(
+    "job_email_delivery", default=None
+)
+
+
+def _deliver(send: Callable[[], bool], description: str) -> None:
+    """Attempt one email send, recording the outcome and failing on rejection.
+
+    ``send`` is the zero-argument send call. A False return means the backend
+    refused the message, which is a real failure rather than something to log
+    over; a True return is noted on the run as delivery having happened.
+    """
+    if not send():
+        raise EmailDeliveryError(f"{description} email send failed")
+    delivery = _current_delivery.get()
+    if delivery is not None:
+        delivery.delivered = True
+
+
 async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-def]
     """Run a job body, timing it and recording its outcome durably.
 
     Writes one append-only ``JobRun`` row — job identifier, start time,
-    duration, status (``success`` / ``skipped`` / ``failed``), and error detail
-    on failure — and emits a structured log line carrying the same facts. A
-    ``PipelineSkip`` is a deliberate no-op (``skipped``); every other exception
-    is a real failure (``failed``). Exceptions never propagate out to the
-    scheduler.
+    duration, status (``success`` / ``skipped`` / ``failed``), error detail on
+    failure, and whether an email was delivered — and emits a structured log
+    line carrying the same facts. A ``PipelineSkip`` is a deliberate no-op
+    (``skipped``); every other exception is a real failure (``failed``).
+    Exceptions never propagate out to the scheduler.
+
+    Delivery is read off the run's ``_Delivery`` tally rather than the body's
+    return value, so it is recorded however the body exited — including a batch
+    that delivered one email and then failed on another.
     """
     started_at = datetime.utcnow()
     start = time.perf_counter()
     status = "success"
     detail: str | None = None  # skip reason or failure message, for the log line
     failure: Exception | None = None
+    delivery = _Delivery()
+    token = _current_delivery.set(delivery)
     try:
         await coro
     except PipelineSkip as e:
@@ -71,6 +122,8 @@ async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-d
         status = "failed"
         detail = str(e)
         failure = e
+    finally:
+        _current_delivery.reset(token)
     duration_ms = int((time.perf_counter() - start) * 1000)
 
     # The row's error column is failure detail only, per the spec; a skip's
@@ -85,6 +138,7 @@ async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-d
                 duration_ms=duration_ms,
                 status=status,
                 error=error,
+                email_delivered=delivery.delivered,
             )
         )
         await session.commit()
@@ -94,6 +148,7 @@ async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-d
         "job_status": status,
         "job_error": error,
         "duration_ms": duration_ms,
+        "email_delivered": delivery.delivered,
     }
     if status == "failed":
         logger.error("Scheduler: %s failed", job_name, exc_info=failure, extra=extra)
@@ -163,7 +218,7 @@ async def _daily_briefing() -> None:
 
         if await _get_user_email_pref("email_daily_briefing"):
             content = json.loads(insight.content)
-            send_daily_briefing(content)
+            _deliver(partial(send_daily_briefing, content), "daily briefing")
             logger.info("Scheduler: daily briefing email sent")
 
 
@@ -204,10 +259,14 @@ async def _weekly_plan() -> None:
                 }
                 for s in sessions
             ]
-            send_weekly_plan(
-                summary=plan.summary or "",
-                sessions=session_dicts,
-                week_start=str(next_monday),
+            _deliver(
+                partial(
+                    send_weekly_plan,
+                    summary=plan.summary or "",
+                    sessions=session_dicts,
+                    week_start=str(next_monday),
+                ),
+                "weekly plan",
             )
             logger.info("Scheduler: weekly plan email sent")
 
@@ -229,7 +288,10 @@ async def _weekly_recap() -> None:
 
         if await _get_user_email_pref("email_weekly_recap"):
             content = json.loads(insight.content)
-            send_weekly_recap(content, week_start=str(last_monday))
+            _deliver(
+                partial(send_weekly_recap, content, week_start=str(last_monday)),
+                "weekly recap",
+            )
             logger.info("Scheduler: weekly recap email sent")
 
 
@@ -295,7 +357,13 @@ async def _post_workout_analysis() -> None:
 
                 if send_email:
                     content = json.loads(insight.content)
-                    send_post_workout(content, activity.title)
+                    # A rejected send lands in ``failures`` below, like any other
+                    # per-activity failure, so one undelivered email neither
+                    # aborts the batch nor passes as delivered.
+                    _deliver(
+                        partial(send_post_workout, content, activity.title),
+                        f"post-workout activity {activity.id}",
+                    )
                     logger.info(
                         "Scheduler: post-workout email sent for activity %d", activity.id
                     )

--- a/tests/test_email/test_sender.py
+++ b/tests/test_email/test_sender.py
@@ -4,15 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from mycoach.config import Settings
 from mycoach.email.sender import (
-<<<<<<< Updated upstream
-    _format_key_metrics,
-=======
-<<<<<<< Updated upstream
-=======
     _format_key_metrics,
     _format_session_details,
->>>>>>> Stashed changes
->>>>>>> Stashed changes
     _render_template,
     send_daily_briefing,
     send_email,
@@ -39,15 +32,7 @@ def _make_settings(**overrides: object) -> Settings:
 
 
 def test_render_daily_briefing_template() -> None:
-<<<<<<< Updated upstream
-    """Daily briefing template renders readiness verdict, explanation, and formatted metrics."""
-=======
-<<<<<<< Updated upstream
-    """Daily briefing template renders with readiness verdict."""
-=======
     """Daily briefing template renders readiness verdict and formatted metrics."""
->>>>>>> Stashed changes
->>>>>>> Stashed changes
     html = _render_template(
         "daily_briefing.html",
         {
@@ -57,43 +42,19 @@ def test_render_daily_briefing_template() -> None:
                 "readiness_explanation": "HRV and sleep both trended up this week",
                 "sleep_assessment": "Good sleep",
                 "workout_adjustments": None,
-<<<<<<< Updated upstream
-                "key_metrics": [{"label": "Resting HR", "value": 52, "unit": "bpm"}],
-=======
-<<<<<<< Updated upstream
-                "key_metrics": {"resting_hr": "52 bpm"},
-=======
                 "key_metrics": {"Resting HR": "52 bpm"},
->>>>>>> Stashed changes
->>>>>>> Stashed changes
                 "sleep_recommendation": "Sleep by 10pm",
             }
         },
     )
     assert "Go Hard" in html
     assert "Fully recovered" in html
-<<<<<<< Updated upstream
-    assert "HRV and sleep both trended up this week" in html
     assert "Resting HR" in html
     assert "52" in html
     assert "bpm" in html
     assert "MyCoach" in html
 
 
-=======
-<<<<<<< Updated upstream
-    assert "52 bpm" in html
-    assert "MyCoach" in html
-
-
-=======
-    assert "Resting HR" in html
-    assert "52" in html
-    assert "bpm" in html
-    assert "MyCoach" in html
-
-
->>>>>>> Stashed changes
 def test_format_key_metrics_maps_labels_and_skips_none() -> None:
     """_format_key_metrics turns raw field names into display rows, dropping absent values."""
     rows = _format_key_metrics(
@@ -105,15 +66,6 @@ def test_format_key_metrics_maps_labels_and_skips_none() -> None:
             "resting_hr": 52,
         }
     )
-<<<<<<< Updated upstream
-    assert rows == [
-        {"label": "Body Battery", "value": 65, "unit": ""},
-        {"label": "Sleep Score", "value": 78, "unit": ""},
-        {"label": "Resting HR", "value": 52, "unit": "bpm"},
-    ]
-
-
-=======
     assert rows == {"Body Battery": "65", "Sleep Score": "78", "Resting HR": "52 bpm"}
     # Display order is the order emails show, so it must survive the mapping.
     assert list(rows) == ["Body Battery", "Sleep Score", "Resting HR"]
@@ -147,8 +99,6 @@ def test_format_session_details_empty() -> None:
     assert _format_session_details({"exercises": []}) == {}
 
 
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 def test_render_weekly_plan_template() -> None:
     """Weekly plan template renders sessions and a gym exercise table."""
     html = _render_template(
@@ -162,25 +112,7 @@ def test_render_weekly_plan_template() -> None:
                     "sport": "gym",
                     "duration_minutes": 60,
                     "notes": "Focus on bench",
-<<<<<<< Updated upstream
-                    "details": {
-                        "exercises": [
-                            {
-                                "name": "Bench Press",
-                                "sets": 4,
-                                "reps": 8,
-                                "target_weight_kg": 60,
-                                "rpe": 8,
-                            }
-                        ]
-                    },
-=======
-<<<<<<< Updated upstream
-                    "details": {"bench_press": "4x8"},
-=======
                     "details": {"Bench Press": "4×8 @ 60kg · RPE 8"},
->>>>>>> Stashed changes
->>>>>>> Stashed changes
                 }
             ],
             "week_start": "2025-03-03",
@@ -190,40 +122,12 @@ def test_render_weekly_plan_template() -> None:
     assert "Upper Body" in html
     assert "gym" in html
     assert "2025-03-03" in html
-<<<<<<< Updated upstream
-=======
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
     assert "Bench Press" in html
     assert "4" in html and "8" in html
     assert "60kg" in html
     assert "RPE 8" in html
 
 
-<<<<<<< Updated upstream
-def test_render_weekly_plan_template_cardio_details_not_rendered() -> None:
-    """Cardio's free-form details dict is not rendered — sessions rely on notes instead."""
-    html = _render_template(
-        "weekly_plan.html",
-        {
-            "summary": "Easy week",
-            "sessions": [
-                {
-                    "day_name": "Tuesday",
-                    "title": "Easy Run",
-                    "sport": "running",
-                    "duration_minutes": 40,
-                    "notes": "Keep it conversational pace",
-                    "details": {"target_pace_min_per_km": 5.5, "hr_zone": 2},
-                }
-            ],
-            "week_start": "2025-03-03",
-        },
-    )
-    assert "Keep it conversational pace" in html
-    assert "target_pace_min_per_km" not in html
-=======
 @patch("mycoach.email.sender.send_email", return_value=True)
 def test_send_weekly_plan_formats_raw_cardio_details(mock_send: MagicMock) -> None:
     """send_weekly_plan humanises raw detail keys before they reach the template."""
@@ -247,8 +151,6 @@ def test_send_weekly_plan_formats_raw_cardio_details(mock_send: MagicMock) -> No
     assert "Target Pace" in html
     assert "5.5 min/km" in html
     assert "target_pace_min_per_km" not in html
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 
 
 def test_render_post_workout_template() -> None:

--- a/tests/test_logging/test_logging_config.py
+++ b/tests/test_logging/test_logging_config.py
@@ -92,6 +92,30 @@ class TestJSONFormatter:
         assert data["job_error"] == "boom"
         assert data["duration_ms"] == 42
 
+    @pytest.mark.parametrize("delivered", [True, False])
+    def test_email_delivered_propagated(self, delivered: bool) -> None:
+        """Delivery reaches the JSON line in both states.
+
+        False is the interesting one: it must survive into the output rather than
+        being dropped as falsy, since "succeeded but delivered nothing" is the
+        combination monitoring alerts on.
+        """
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="mycoach.scheduler.jobs",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Scheduler: daily_briefing succeeded",
+            args=(),
+            exc_info=None,
+        )
+        record.job_name = "daily_briefing"  # type: ignore[attr-defined]
+        record.job_status = "success"  # type: ignore[attr-defined]
+        record.email_delivered = delivered  # type: ignore[attr-defined]
+        data = json.loads(formatter.format(record))
+        assert data["email_delivered"] is delivered
+
     def test_output_is_single_line(self) -> None:
         formatter = JSONFormatter()
         record = logging.LogRecord(

--- a/tests/test_scheduler/test_job_runs.py
+++ b/tests/test_scheduler/test_job_runs.py
@@ -455,3 +455,271 @@ async def test_post_workout_failed_email_counts_the_activity_once() -> None:
     assert runs[0].status == "failed"
     assert runs[0].error is not None
     assert "1 of 1 activities failed" in runs[0].error
+
+
+# --- email delivery outcome ---------------------------------------------------
+#
+# Delivery is recorded as its own fact, independent of status, so the three
+# distinguishable cases are (status, email_delivered) pairs:
+#   delivered              -> ("success", True)
+#   not attempted          -> ("success", False)   e.g. the type is switched off
+#   attempted and rejected -> ("failed",  False)
+
+
+def _briefing_engine() -> MagicMock:
+    """Engine whose briefing insight carries JSON the email formatter can read."""
+    engine = MagicMock()
+    engine.generate_daily_briefing = AsyncMock(
+        return_value=MagicMock(content='{"readiness_verdict": "go_hard"}')
+    )
+    return engine
+
+
+async def test_records_email_delivered_when_send_succeeds() -> None:
+    """A send that reports success records the run as having delivered an email."""
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_daily_briefing", return_value=True),
+    ):
+        await _record_run("daily_briefing", _daily_briefing())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "success"
+    assert runs[0].email_delivered is True
+
+
+async def test_records_email_not_delivered_when_type_is_disabled() -> None:
+    """A recipient with this email type switched off is a success, nothing sent.
+
+    Not sending was intended, so the run must not be downgraded — the absence of
+    delivery is carried by ``email_delivered``, not by the status.
+    """
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        patch("mycoach.scheduler.jobs.send_daily_briefing") as mock_send,
+    ):
+        await _record_run("daily_briefing", _daily_briefing())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "success"
+    assert runs[0].email_delivered is False
+    mock_send.assert_not_called()
+
+
+async def test_rejected_send_fails_the_run_with_the_cause() -> None:
+    """A send that is attempted and rejected makes the run a failure."""
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_daily_briefing", return_value=False),
+    ):
+        await _record_run("daily_briefing", _daily_briefing())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].email_delivered is False
+    assert runs[0].error is not None
+    assert "daily briefing" in runs[0].error
+    assert "email" in runs[0].error
+
+
+async def test_delivery_appears_in_the_structured_log_line(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The log line carries the delivery fact alongside the other run facts."""
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_daily_briefing", return_value=True),
+        caplog.at_level(logging.INFO),
+    ):
+        await _record_run("daily_briefing", _daily_briefing())
+
+    outcome = [r for r in caplog.records if getattr(r, "job_name", None) == "daily_briefing"]
+    assert outcome
+    assert outcome[-1].email_delivered is True
+
+
+async def test_non_sending_job_records_no_delivery() -> None:
+    """Garmin sync sends no email, so it records delivery as not sent."""
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=_mock_garmin_source()),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch(
+            "mycoach.scheduler.jobs.merge_garmin_hevy",
+            AsyncMock(return_value=MagicMock(merged=0)),
+        ),
+    ):
+        await _record_run("garmin_sync", _garmin_sync())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "success"
+    assert runs[0].email_delivered is False
+
+
+async def test_weekly_plan_records_delivery() -> None:
+    """A delivered weekly-plan email is recorded on the run."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_plan = AsyncMock(
+        return_value=MagicMock(id=1, summary="Big week")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_weekly_plan", return_value=True),
+    ):
+        await _record_run("weekly_plan", _weekly_plan())
+
+    runs = await _job_runs()
+    assert runs[0].status == "success"
+    assert runs[0].email_delivered is True
+
+
+async def test_weekly_plan_rejected_send_fails_the_run() -> None:
+    """A rejected weekly-plan send fails the run even though the plan generated."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_plan = AsyncMock(
+        return_value=MagicMock(id=1, summary="Big week")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_weekly_plan", return_value=False),
+    ):
+        await _record_run("weekly_plan", _weekly_plan())
+
+    runs = await _job_runs()
+    assert runs[0].status == "failed"
+    assert runs[0].email_delivered is False
+    assert runs[0].error is not None
+    assert "weekly plan" in runs[0].error
+
+
+async def test_weekly_recap_records_delivery() -> None:
+    """A delivered weekly-recap email is recorded on the run."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_recap = AsyncMock(
+        return_value=MagicMock(content='{"week_summary": "Solid"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_weekly_recap", return_value=True),
+    ):
+        await _record_run("weekly_recap", _weekly_recap())
+
+    runs = await _job_runs()
+    assert runs[0].status == "success"
+    assert runs[0].email_delivered is True
+
+
+async def test_weekly_recap_rejected_send_fails_the_run() -> None:
+    """A rejected weekly-recap send fails the run with the cause captured."""
+    mock_engine = MagicMock()
+    mock_engine.generate_weekly_recap = AsyncMock(
+        return_value=MagicMock(content='{"week_summary": "Solid"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_weekly_recap", return_value=False),
+    ):
+        await _record_run("weekly_recap", _weekly_recap())
+
+    runs = await _job_runs()
+    assert runs[0].status == "failed"
+    assert runs[0].email_delivered is False
+    assert runs[0].error is not None
+    assert "weekly recap" in runs[0].error
+
+
+async def test_post_workout_records_delivery() -> None:
+    """A delivered post-workout email is recorded on the batch's single run."""
+    await _add_activities(1)
+    mock_engine = MagicMock()
+    mock_engine.generate_post_workout_analysis = AsyncMock(
+        return_value=MagicMock(content='{"performance_summary": "ok"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_post_workout", return_value=True),
+    ):
+        await _record_run("post_workout_analysis", _post_workout_analysis())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "success"
+    assert runs[0].email_delivered is True
+
+
+async def test_post_workout_rejected_send_fails_the_run() -> None:
+    """A rejected post-workout send is tallied as that activity's failure."""
+    await _add_activities(1)
+    mock_engine = MagicMock()
+    mock_engine.generate_post_workout_analysis = AsyncMock(
+        return_value=MagicMock(content='{"performance_summary": "ok"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_post_workout", return_value=False),
+    ):
+        await _record_run("post_workout_analysis", _post_workout_analysis())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].email_delivered is False
+    assert runs[0].error is not None
+    assert "1 of 1 activities failed" in runs[0].error
+
+
+async def test_post_workout_partial_delivery_is_still_recorded_as_delivered() -> None:
+    """One rejected send out of two fails the run, but an email did go out.
+
+    Status and delivery are separate facts precisely so this run can say both
+    things at once; folding delivery into the status would lose one of them.
+    """
+    await _add_activities(2)
+    mock_engine = MagicMock()
+    mock_engine.generate_post_workout_analysis = AsyncMock(
+        return_value=MagicMock(content='{"performance_summary": "ok"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_post_workout", side_effect=[True, False]),
+    ):
+        await _record_run("post_workout_analysis", _post_workout_analysis())
+
+    runs = await _job_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].email_delivered is True
+    assert runs[0].error is not None
+    assert "1 of 2 activities failed" in runs[0].error

--- a/tests/test_scheduler/test_job_runs.py
+++ b/tests/test_scheduler/test_job_runs.py
@@ -434,13 +434,8 @@ async def test_post_workout_failed_email_counts_the_activity_once() -> None:
     twice would persist a wrong denominator ("1 of 2" for a single activity).
     """
     await _add_activities(1)
-    mock_engine = MagicMock()
-    mock_engine.generate_post_workout_analysis = AsyncMock(
-        return_value=MagicMock(content='{"performance_summary": "ok"}')
-    )
-
     with (
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_post_workout_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
         patch(
@@ -471,6 +466,31 @@ def _briefing_engine() -> MagicMock:
     engine = MagicMock()
     engine.generate_daily_briefing = AsyncMock(
         return_value=MagicMock(content='{"readiness_verdict": "go_hard"}')
+    )
+    return engine
+
+
+def _plan_engine() -> MagicMock:
+    """Engine returning a plan with a real int id, so the session lookup binds."""
+    engine = MagicMock()
+    engine.generate_weekly_plan = AsyncMock(return_value=MagicMock(id=1, summary="Big week"))
+    return engine
+
+
+def _recap_engine() -> MagicMock:
+    """Engine whose recap insight carries JSON the email formatter can read."""
+    engine = MagicMock()
+    engine.generate_weekly_recap = AsyncMock(
+        return_value=MagicMock(content='{"week_summary": "Solid"}')
+    )
+    return engine
+
+
+def _post_workout_engine() -> MagicMock:
+    """Engine whose post-workout insight carries JSON the email formatter can read."""
+    engine = MagicMock()
+    engine.generate_post_workout_analysis = AsyncMock(
+        return_value=MagicMock(content='{"performance_summary": "ok"}')
     )
     return engine
 
@@ -569,13 +589,8 @@ async def test_non_sending_job_records_no_delivery() -> None:
 
 async def test_weekly_plan_records_delivery() -> None:
     """A delivered weekly-plan email is recorded on the run."""
-    mock_engine = MagicMock()
-    mock_engine.generate_weekly_plan = AsyncMock(
-        return_value=MagicMock(id=1, summary="Big week")
-    )
-
     with (
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_plan_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
         patch("mycoach.scheduler.jobs.send_weekly_plan", return_value=True),
@@ -589,13 +604,8 @@ async def test_weekly_plan_records_delivery() -> None:
 
 async def test_weekly_plan_rejected_send_fails_the_run() -> None:
     """A rejected weekly-plan send fails the run even though the plan generated."""
-    mock_engine = MagicMock()
-    mock_engine.generate_weekly_plan = AsyncMock(
-        return_value=MagicMock(id=1, summary="Big week")
-    )
-
     with (
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_plan_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
         patch("mycoach.scheduler.jobs.send_weekly_plan", return_value=False),
@@ -611,13 +621,8 @@ async def test_weekly_plan_rejected_send_fails_the_run() -> None:
 
 async def test_weekly_recap_records_delivery() -> None:
     """A delivered weekly-recap email is recorded on the run."""
-    mock_engine = MagicMock()
-    mock_engine.generate_weekly_recap = AsyncMock(
-        return_value=MagicMock(content='{"week_summary": "Solid"}')
-    )
-
     with (
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_recap_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
         patch("mycoach.scheduler.jobs.send_weekly_recap", return_value=True),
@@ -631,13 +636,8 @@ async def test_weekly_recap_records_delivery() -> None:
 
 async def test_weekly_recap_rejected_send_fails_the_run() -> None:
     """A rejected weekly-recap send fails the run with the cause captured."""
-    mock_engine = MagicMock()
-    mock_engine.generate_weekly_recap = AsyncMock(
-        return_value=MagicMock(content='{"week_summary": "Solid"}')
-    )
-
     with (
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_recap_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
         patch("mycoach.scheduler.jobs.send_weekly_recap", return_value=False),
@@ -654,13 +654,8 @@ async def test_weekly_recap_rejected_send_fails_the_run() -> None:
 async def test_post_workout_records_delivery() -> None:
     """A delivered post-workout email is recorded on the batch's single run."""
     await _add_activities(1)
-    mock_engine = MagicMock()
-    mock_engine.generate_post_workout_analysis = AsyncMock(
-        return_value=MagicMock(content='{"performance_summary": "ok"}')
-    )
-
     with (
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_post_workout_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
         patch("mycoach.scheduler.jobs.send_post_workout", return_value=True),
@@ -676,13 +671,8 @@ async def test_post_workout_records_delivery() -> None:
 async def test_post_workout_rejected_send_fails_the_run() -> None:
     """A rejected post-workout send is tallied as that activity's failure."""
     await _add_activities(1)
-    mock_engine = MagicMock()
-    mock_engine.generate_post_workout_analysis = AsyncMock(
-        return_value=MagicMock(content='{"performance_summary": "ok"}')
-    )
-
     with (
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_post_workout_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
         patch("mycoach.scheduler.jobs.send_post_workout", return_value=False),
@@ -704,13 +694,8 @@ async def test_post_workout_partial_delivery_is_still_recorded_as_delivered() ->
     things at once; folding delivery into the status would lose one of them.
     """
     await _add_activities(2)
-    mock_engine = MagicMock()
-    mock_engine.generate_post_workout_analysis = AsyncMock(
-        return_value=MagicMock(content='{"performance_summary": "ok"}')
-    )
-
     with (
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_post_workout_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
         patch("mycoach.scheduler.jobs.send_post_workout", side_effect=[True, False]),


### PR DESCRIPTION
Jobs discarded the boolean returned by the email send functions, so a rejected send was still followed by a log line saying the email was sent. Combined with delivery having been globally disabled, the system reported successful sends that never happened.

Delivery is now recorded as its own fact, deliberately kept out of the status vocabulary rather than folded into it, so all three outcomes stay distinguishable:

| outcome | `status` | `email_delivered` |
| --- | --- | --- |
| delivered | `success` | `true` |
| not attempted — recipient has the type switched off | `success` | `false` |
| attempted and rejected | `failed` | `false` |

A run whose insight generated correctly but whose recipient has that email type disabled is a genuine success that sent nothing — not sending was intended. A run whose send was attempted and rejected is a failure. One field represents both, and lets monitoring alert on "jobs succeeding but nothing being delivered" without the status having to encode it.

## Implementation

- `_deliver` wraps every send call. A `False` return raises `EmailDeliveryError`, so the rejection reaches `_record_run` as an ordinary failure with the cause captured; a `True` return is noted on the run.
- `_deliver` also owns the "email sent" log line. That line can no longer structurally precede a send that didn't report success — which is the bug being fixed, so it shouldn't be re-openable by adding a fifth call site.
- Delivery rides a per-run `_Delivery` in a `ContextVar` rather than the body's return value. The post-workout batch can deliver one email and *then* fail on another; a return value would lose that. A test pins `("failed", email_delivered=True)` for exactly that case.
- New `job_runs.email_delivered` column (migration `f6a7b8c9d0e1`, additive with `server_default=false`) plus the `email_delivered` key on the structured log line.

All four sending bodies route through `_deliver` — daily briefing, weekly plan, weekly recap, and the post-workout batch. `_garmin_sync` sends no email and records `false` by default.

## Acceptance criteria

- [x] Jobs inspect the result of attempting to send and no longer claim success unconditionally
- [x] A send that is attempted and fails makes the run a failure, with the cause captured
- [x] Every run records whether an email was actually delivered
- [x] A run where the recipient has that email type disabled remains a success with delivery recorded as not sent
- [x] The delivery field appears in both the persisted record and the structured log line
- [x] Tests cover delivered, not-attempted, and attempted-but-failed cases

## Prerequisite repair — `main` does not currently boot

`623fcad "feat: fix email templates"` committed the raw output of an unresolved `git stash pop`: nested `<<<<<<< Updated upstream` / `>>>>>>> Stashed changes` markers across `sender.py`, four templates, and `test_sender.py`. `<<<<<<<` is not valid Python, so `sender.py` raises `SyntaxError` on import — and since `main.py` → `scheduler.scheduler` → `jobs` → `email.sender` is a module-level chain, **the entire app fails to start at `main`, not just email.** Merging this PR restores it.

`394ebde` resolves the markers to the "Stashed changes" side throughout (the redesigned template work the accompanying tests exercise), with two places where a blanket resolution was wrong:

- `weekly_recap.html` — restored the `coach_recommendations` block, which existed only on the upstream side but is a real field the v2 prompt emits and `test_render_weekly_recap_template` asserts on.
- `daily_briefing.html` — dropped duplicated `key_metrics` / `sleep_assessment` / `workout_adjustments` blocks, keeping the versions consistent with `_format_key_metrics` returning a label → value dict.

**This half deserves the closer review**, since it infers intent from a broken commit rather than from a spec.

Worth adding separately: no hook or CI gate catches this class of mistake. `git diff --check` plus a compile step would have rejected `623fcad` in under a second.

## Verification

- 573 tests pass — 559 before this branch, 14 new.
- `mypy` and `ruff` clean on every touched file; only pre-existing violations elsewhere remain.
- Migration verified up → down → up against a copy of a real database, confirming `server_default` backfills `false` for existing rows.

## Known limitation

The captured cause is `"<label> email send failed"`, not the underlying SMTP/Resend exception, because the send functions return only a `bool`. Threading the real exception through means changing that contract across `sender.py` — out of scope here, and the issue's own framing ("the boolean returned by the email send function") treats the bool as given. Worth its own issue if we want richer detail.

Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
