### PR TITLE
feat(email): carry the backend's rejection reason into the run record

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,9 +5,15 @@
 
 ---
 
-## Current Phase: 0 — Foundation
+## Current Phase: 9 — Companion logger & cleanup
 
-**Status:** In progress
+**Status:** In progress. Phases 0–8 are implemented; the automation pipeline was
+verified end to end on 2026-07-28 (see the log entry for that date). Remaining
+work is ordered in TODO.md's "Next Steps" section.
+
+> This file was itself stale for months — the phase table below still read "Not
+> started" for every phase long after they shipped. Entries between 2026-02-13
+> and 2026-07-28 are missing; the git history is the record for that period.
 
 ---
 
@@ -48,21 +54,109 @@
 - **Email:** Resend or SMTP for plan/briefing delivery.
 - **No paid subscriptions** required beyond Claude API (~$20-30/month).
 
+### 2026-07-28 — End-to-end automation verification (Step 1 closed)
+
+Every scheduled job was triggered by hand through
+`POST /api/system/scheduler/trigger/{job}` against the real Garmin account and
+the live Resend backend, and the resulting `job_runs` rows were reconciled
+against the actual inbox.
+
+| # | Job | Status | Delivered | Note |
+|---|-----|--------|-----------|------|
+| 1 | `garmin_sync` | success | — | 3 health snapshots, 0 new activities |
+| 2 | `daily_briefing` | success | ✅ 12:53:59Z | briefing email arrived |
+| 3 | `weekly_recap` | success | ✅ 12:54:39Z | recap for week of 2026-07-20 arrived |
+| 4 | `daily_briefing` | skipped | — | briefing already existed — 13 ms, no send |
+| 5 | `post_workout_analysis` | skipped | — | no new activities — 14 ms, no send |
+| 6 | `weekly_plan` | skipped | — | no availability set for w/c 2026-08-03 |
+| 7 | `daily_briefing` | **failed** | — | induced: invalid Resend key |
+| 8 | `daily_briefing` | success | ✅ 12:56:57Z | recovery after restoring the key |
+
+Runs 7 and 8 needed the briefing job to reach its send step, which run 4 shows
+it will not do once a briefing exists for the day. Today's `daily_briefing`
+insight was therefore deleted before each of them, so the job would regenerate
+and attempt a send. Runs 4, 7 and 8 are all honest records — but they are not a
+sequence the job could have produced unaided, and a later reader should not
+puzzle over it.
+
+Runs 5 and 6 skipped for want of input, which means the **post-workout** and
+**weekly-plan** emails were never attempted: two of the four templates are still
+unobserved in a real inbox. Carried as an open item in TODO.md Step 1 rather
+than counted as verified here.
+
+**Reconciliation:** exactly three runs recorded `email_delivered = true` and
+exactly three messages arrived, timestamps matching to the second. No run
+reported success without a corresponding delivery. Each skip was a genuine
+no-op — all three finished in well under half a second, before any LLM call or
+send, for a stated reason.
+
+**Induced failure.** Run 7 was driven with a deliberately invalid Resend API
+key. Its recorded error reads in full:
+
+> `daily briefing email send failed — Resend rejected the message: API key is invalid`
+
+That is diagnosable without consulting any other table or log. Getting there
+required a code change, not just a check: the backends previously swallowed the
+rejection reason and returned `False`, so the run would have recorded only
+"daily briefing email send failed". `email/sender.py` now raises
+`EmailSendError` carrying the backend's own words, and a `False` return means
+only that no backend was available to attempt the send at all.
+
+**What the audit established, and what the docs had wrong:**
+
+- **The email phase was ticked complete having never sent a message.** Phase 7
+  was marked ✅ on 2026-07-12 on the strength of the code existing and the
+  triggers being wired. No real delivery had ever happened. TODO.md's Phase 7
+  note now says so.
+- **The roadmap's email-configuration item was not merely unverified — it was
+  false.** Step 1 carried "confirm `.env` is set for real delivery" as an
+  unchecked box; the truth was that it was *not* set, so every send would have
+  returned False. Compounding it, jobs discarded that False and logged "email
+  sent" anyway until #9.
+- **The March→July gap in coaching output was disuse, not a defect.** Insights
+  run daily through 2026-03-18, then stop until 2026-07-10; activity data has
+  the same shape, with nothing logged between 2026-03-10 and 2026-07-12. The app
+  simply was not being run or fed during that window. Nothing in the scheduler
+  misfired — the jobs are idempotent and skip cleanly when there is no new data,
+  which is precisely what runs 4–6 above demonstrate.
+
+**Follow-ups recorded in TODO.md Step 1 rather than left implicit:** verifying a
+custom sending domain (mail currently leaves as `onboarding@resend.dev`,
+Resend's shared sandbox sender), and wiring `job_runs` into an observability
+stack once one exists — nothing consumes the rows today, so this reconciliation
+remains a manual exercise.
+
+**One observation, not yet explained:** a daily briefing also arrived at
+05:30:19Z, before any of the above, matching the deployed instance's 06:30
+Europe/London schedule. It has no corresponding row in this local `job_runs`
+table and no matching insight in this database, so that deployment is running
+against its own data. Run history is therefore per-instance, which is worth
+keeping in mind before treating any single `job_runs` table as the whole story.
+
 ---
 
 ## Phase Summary
 
+Two statuses, deliberately kept apart — conflating them is how Phase 7 came to
+be ticked complete having never sent a message:
+
+- **Implemented** — the code exists and reads correct. This is what the
+  2026-07-12/16 audits established, and it is all they could establish.
+- **Verified** — the behaviour has been observed working against real data and
+  real backends, with a date naming the run.
+
 | Phase | Name | Status | Started | Completed |
 |-------|------|--------|---------|-----------|
-| 0 | Foundation | Not started | — | — |
-| 1 | Data Sources | Not started | — | — |
-| 2 | Coaching Core | Not started | — | — |
-| 3 | Weekly Plans | Not started | — | — |
-| 4 | Post-Workout | Not started | — | — |
-| 5 | Automation | Not started | — | — |
-| 6 | PWA Frontend | Not started | — | — |
-| 7 | Email | Not started | — | — |
-| 8 | Polish | Not started | — | — |
+| 0 | Foundation | Implemented (audit 2026-07-12) | 2026-02-13 | — |
+| 1 | Data Sources | Implemented (audit 2026-07-12) | — | — |
+| 2 | Coaching Core | Implemented (audit 2026-07-12) | — | — |
+| 3 | Weekly Plans | Implemented (audit 2026-07-12) | — | — |
+| 4 | Post-Workout | Implemented (audit 2026-07-12) | — | — |
+| 5 | Automation | **Verified** end to end 2026-07-28 | — | 2026-07-28 |
+| 6 | PWA Frontend | Implemented, less settings + workout-detail pages | — | — |
+| 7 | Email | **Verified** for briefing + recap 2026-07-28; weekly-plan and post-workout emails still unobserved | — | — |
+| 8 | Polish | Implemented (audit 2026-07-12) | — | — |
+| 9 | Companion logger & cleanup | In progress | — | — |
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,10 +5,8 @@
 ## 🧭 Next Steps (current roadmap) — start here
 
 > Codebase audit (2026-07-12, re-verified 2026-07-16) confirmed **Phases 0–8 are
-> implemented and functional** — the daily morning digest and weekly recap
-> pipelines already run end-to-end (scheduler → coaching engine → email). The
-> checklists for those phases below are kept for history; the real remaining
-> work is ordered here.
+> implemented**. The checklists for those phases below are kept for history; the
+> real remaining work is ordered here.
 >
 > Priority chosen: **verify automation first → gym logger → cleanup.**
 >
@@ -17,24 +15,59 @@
 > schedule-config items were also already done (`6e14572`). The
 > `POST /api/system/scheduler/trigger/{job}` endpoint Step 1 depends on has now
 > been added (`api/routes/system.py`), unblocking end-to-end verification.
+>
+> **2026-07-28:** Step 1 is now **done** — the daily and weekly pipelines have
+> been run end to end (scheduler → coaching engine → Resend → inbox) and the run
+> records reconciled against delivered mail. The earlier wording above claimed
+> those pipelines "already run end-to-end"; that was an inference from reading
+> the code, and on the email leg it was wrong — see Phase 7's note below.
 
-### Step 1 — Verify & harden the automation (do first)
+### Step 1 — Verify & harden the automation — ✅ Done (2026-07-28)
 
-- [ ] End-to-end verify the **daily** pipeline: manually trigger `garmin_sync`
-      then `daily_briefing` (via `POST /api/system/scheduler/trigger/{job}`,
-      API-key guarded) and confirm a real briefing email lands in the inbox.
-- [ ] End-to-end verify the **weekly recap**: trigger `weekly_recap`, confirm the
-      `weekly_recap.html` email arrives with adherence + health trends + AI tips.
-- [ ] Confirm `.env` is set for real delivery: `MYCOACH_EMAIL_ENABLED=true`,
-      `MYCOACH_EMAIL_FROM`, `MYCOACH_EMAIL_TO`, and either
-      `MYCOACH_EMAIL_RESEND_API_KEY` or the `MYCOACH_EMAIL_SMTP_*` set.
-- [ ] Confirm per-user email prefs on the `User` row are enabled
-      (`email_daily_briefing`, `email_weekly_recap`, `email_weekly_plan`,
-      `email_post_workout`) — jobs silently skip sending when these are false.
+Verified end to end on 2026-07-28 by triggering every job through
+`POST /api/system/scheduler/trigger/{job}` against real Garmin data and the live
+Resend backend, then reconciling the `job_runs` rows against the inbox. Full
+account in PROGRESS.md ("2026-07-28 — End-to-end automation verification").
+
+- [x] End-to-end verify the **daily** pipeline: `garmin_sync` succeeded
+      (3 health snapshots), `daily_briefing` succeeded, briefing email delivered.
+- [x] End-to-end verify the **weekly recap**: `weekly_recap` succeeded and the
+      `weekly_recap.html` email arrived with adherence + health trends + tips.
+- [x] Confirm `.env` is set for real delivery — it is, via
+      `MYCOACH_EMAIL_RESEND_API_KEY`. **Note:** this item was previously carried
+      as merely unverified, but it had in fact been *false* until #4 — email had
+      never been configured for real delivery and no message had ever been sent,
+      despite Phase 7 being ticked complete below.
+- [x] Confirm per-user email prefs on the `User` row are enabled — all four
+      (`email_daily_briefing`, `email_weekly_plan`, `email_post_workout`,
+      `email_weekly_recap`) are on for user 1.
+- [x] A deliberately induced failure (invalid Resend key) recorded a `failed` run
+      whose error diagnoses it unaided: `daily briefing email send failed —
+      Resend rejected the message: API key is invalid`. Making the backend's
+      reason survive into `JobRun.error` was a code change, not just a check —
+      `EmailSendError` in `email/sender.py`; a `False` return now means only
+      "no backend was available to attempt the send".
 
 > ✅ Done: weekly-recap schedule and weekly-plan minute are config-driven
 > (`scheduler_weekly_recap_day/_hour/_minute`, `scheduler_weekly_plan_minute` in
 > `config.py` + `.env.example`, wired in `scheduler/scheduler.py`) — `6e14572`.
+
+**Remaining follow-up from this step** (tracked here rather than left implicit):
+
+- [ ] Send from a verified custom domain. Mail currently goes out as
+      `onboarding@resend.dev`, Resend's shared sandbox sender — fine for a
+      single-user inbox, but it is not the project's own domain and carries no
+      SPF/DKIM alignment of its own. Verify a domain in Resend and repoint
+      `MYCOACH_EMAIL_FROM`.
+- [ ] Observe the **weekly-plan** and **post-workout** emails in an inbox. Both
+      jobs skipped on 2026-07-28 for want of input, so those two of the four
+      templates have still never been delivered for real. Set availability for a
+      week and log an activity, then re-trigger.
+- [ ] Feed `job_runs` into an observability stack once one exists. The rows and
+      the structured log lines carry everything needed to alert on "succeeding
+      but not delivering", but nothing consumes them today — verification is
+      still a manual reconciliation. No such stack exists yet, so this is
+      deliberately deferred rather than scoped here.
 
 ### Step 2 — Retire Hevy web-API auto-sync (keep CSV) — ✅ Done
 
@@ -347,8 +380,18 @@ pending an actual home-server deploy (tracked outside this file).
 ## Phase 7: Email Delivery (Week 7-8)
 
 > ✅ **COMPLETE** — Resend + SMTP backends, all 4 templates, per-user prefs,
-> triggers wired into scheduler jobs (audit 2026-07-12). End-to-end delivery
-> verification tracked in **Step 1** above.
+> triggers wired into scheduler jobs (audit 2026-07-12); first real delivery
+> 2026-07-28 (#4). The **daily briefing** and **weekly recap** emails are
+> verified end to end in **Step 1** above. The weekly-plan and post-workout
+> emails are *not* yet observed in an inbox — their jobs skipped for want of
+> input data (no availability set, no new activities), so no send was attempted.
+>
+> ⚠️ **This phase was marked complete on 2026-07-12 without a single message
+> having been sent.** The audit checked that the code existed and the triggers
+> were wired, and read that as done. It was not: `.env` had no working backend,
+> so every send would have returned False — and, until #9, jobs discarded that
+> False and logged "email sent" regardless. "Implemented" and "works" are not the
+> same claim, and this file should not tick a phase on the former.
 
 - [ ] Set up email service (Resend API or SMTP)
 - [ ] Create HTML email templates (responsive, email-client compatible)

--- a/src/mycoach/email/__init__.py
+++ b/src/mycoach/email/__init__.py
@@ -1,4 +1,5 @@
 from mycoach.email.sender import (
+    EmailSendError,
     send_daily_briefing,
     send_email,
     send_post_workout,
@@ -7,6 +8,7 @@ from mycoach.email.sender import (
 )
 
 __all__ = [
+    "EmailSendError",
     "send_daily_briefing",
     "send_email",
     "send_post_workout",

--- a/src/mycoach/email/sender.py
+++ b/src/mycoach/email/sender.py
@@ -24,6 +24,18 @@ _jinja_env = Environment(
 )
 
 
+class EmailSendError(RuntimeError):
+    """A backend was asked to send a message and refused, with its reason.
+
+    Raised instead of returning False so the reason the backend gave survives to
+    whoever reads the failure. A scheduled job's ``JobRun.error`` is the only
+    durable account of why a run failed; collapsing "Resend says the sender
+    domain is unverified" into a bare False forced that reader back into the
+    logs to re-derive it. A False return now means only that no backend was
+    available to attempt the send at all.
+    """
+
+
 def _render_template(template_name: str, context: dict) -> str:  # type: ignore[type-arg]
     """Render a Jinja2 email template with the given context."""
     template = _jinja_env.get_template(template_name)
@@ -123,8 +135,12 @@ def _dashboard_url(settings: Settings) -> str:
     return f"{settings.app_base_url}/dashboard"
 
 
-def _send_via_resend(settings: Settings, to: str, subject: str, html: str) -> bool:
-    """Send email using Resend API."""
+def _send_via_resend(settings: Settings, to: str, subject: str, html: str) -> None:
+    """Send email using Resend API.
+
+    Returns only once Resend has accepted the message; raises ``EmailSendError``
+    carrying Resend's own words if it refuses.
+    """
     resend.api_key = settings.email_resend_api_key
     try:
         resend.Emails.send(
@@ -135,14 +151,17 @@ def _send_via_resend(settings: Settings, to: str, subject: str, html: str) -> bo
                 "html": html,
             }
         )
-        return True
-    except Exception:
+    except Exception as e:
         logger.exception("Resend send failed")
-        return False
+        raise EmailSendError(f"Resend rejected the message: {e}") from e
 
 
-def _send_via_smtp(settings: Settings, to: str, subject: str, html: str) -> bool:
-    """Send email using SMTP."""
+def _send_via_smtp(settings: Settings, to: str, subject: str, html: str) -> None:
+    """Send email using SMTP.
+
+    Returns only once the server has accepted the message; raises
+    ``EmailSendError`` carrying its own words if it refuses.
+    """
     msg = MIMEMultipart("alternative")
     msg["From"] = settings.email_from
     msg["To"] = to
@@ -157,16 +176,21 @@ def _send_via_smtp(settings: Settings, to: str, subject: str, html: str) -> bool
             if settings.email_smtp_user:
                 server.login(settings.email_smtp_user, settings.email_smtp_password)
             server.sendmail(settings.email_from, to, msg.as_string())
-        return True
-    except Exception:
+    except Exception as e:
         logger.exception("SMTP send failed")
-        return False
+        raise EmailSendError(
+            f"SMTP host {settings.email_smtp_host}:{settings.email_smtp_port} "
+            f"rejected the message: {e}"
+        ) from e
 
 
 def send_email(to: str, subject: str, html: str, settings: Settings | None = None) -> bool:
     """Send an email using the configured backend.
 
-    Returns True on success, False on failure.
+    Returns True once a backend has accepted the message, and False when there
+    was no backend to attempt it — email switched off, or none configured. A
+    backend that attempts the send and refuses raises ``EmailSendError`` so its
+    reason is not lost.
     """
     if settings is None:
         settings = get_settings()
@@ -176,12 +200,13 @@ def send_email(to: str, subject: str, html: str, settings: Settings | None = Non
         return False
 
     if settings.email_resend_api_key:
-        return _send_via_resend(settings, to, subject, html)
+        _send_via_resend(settings, to, subject, html)
     elif settings.email_smtp_host:
-        return _send_via_smtp(settings, to, subject, html)
+        _send_via_smtp(settings, to, subject, html)
     else:
         logger.warning("No email backend configured (no Resend API key or SMTP host)")
         return False
+    return True
 
 
 def send_daily_briefing(content: dict, settings: Settings | None = None) -> bool:  # type: ignore[type-arg]

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -22,6 +22,7 @@ from mycoach.coaching.exceptions import PipelineSkip
 from mycoach.config import get_settings
 from mycoach.database import async_session
 from mycoach.email.sender import (
+    EmailSendError,
     send_daily_briefing,
     send_post_workout,
     send_weekly_plan,
@@ -52,12 +53,12 @@ def _run_async(coro):  # type: ignore[no-untyped-def]
 
 
 class EmailDeliveryError(RuntimeError):
-    """An email send was attempted and rejected by the backend.
+    """An email a job meant to send did not go out.
 
-    Raised by ``_deliver`` so a rejected send reaches ``_record_run`` as an
-    ordinary failure. The send functions signal rejection by returning False,
-    which jobs previously discarded — logging "email sent" for a send that never
-    happened.
+    Raised by ``_deliver`` so an undelivered email reaches ``_record_run`` as an
+    ordinary failure — jobs previously discarded the send outcome, logging
+    "email sent" for a send that never happened. The message names the email and
+    the cause, because ``JobRun.error`` is all a reader gets.
     """
 
 
@@ -79,18 +80,29 @@ _current_delivery: ContextVar[_Delivery | None] = ContextVar(
 
 
 def _deliver(send: Callable[[], bool], email_label: str) -> None:
-    """Attempt one email send, recording the outcome and failing on rejection.
+    """Attempt one email send, recording the outcome and failing if nothing went out.
 
-    ``send`` is the zero-argument send call. A False return means the backend
-    refused the message, which is a real failure rather than something to log
-    over; a True return is noted on the run as delivery having happened.
+    ``send`` is the zero-argument send call. Either way it fails to deliver is a
+    real failure rather than something to log over, and the two ways differ in
+    what a reader has to do about them: an ``EmailSendError`` is a backend that
+    refused and said why, while a False return is no backend having been
+    available to try — a configuration fault. Both are re-raised naming the
+    email and the cause, since the run's error column is the only durable
+    account. A True return is noted on the run as delivery having happened.
 
     The "email sent" log line lives here rather than at the call sites so it can
     only ever follow a send that actually reported success — the bug this helper
     exists to prevent was exactly that line being logged unconditionally.
     """
-    if not send():
-        raise EmailDeliveryError(f"{email_label} email send failed")
+    try:
+        sent = send()
+    except EmailSendError as e:
+        raise EmailDeliveryError(f"{email_label} email send failed — {e}") from e
+    if not sent:
+        raise EmailDeliveryError(
+            f"{email_label} email send failed — no email backend was available to "
+            f"attempt it (check MYCOACH_EMAIL_ENABLED and the Resend/SMTP settings)"
+        )
     delivery = _current_delivery.get()
     if delivery is not None:
         delivery.delivered = True

--- a/tests/test_email/test_sender.py
+++ b/tests/test_email/test_sender.py
@@ -2,8 +2,11 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from mycoach.config import Settings
 from mycoach.email.sender import (
+    EmailSendError,
     _format_key_metrics,
     _format_session_details,
     _render_template,
@@ -263,12 +266,35 @@ def test_send_email_via_smtp(mock_smtp_class: MagicMock) -> None:
 
 
 @patch("mycoach.email.sender.resend")
-def test_send_email_resend_failure(mock_resend: MagicMock) -> None:
-    """Returns False and logs when Resend raises."""
-    mock_resend.Emails.send.side_effect = Exception("API error")
+def test_send_email_resend_failure_carries_the_backend_reason(mock_resend: MagicMock) -> None:
+    """A Resend rejection raises with the backend's own words, not a bare False.
+
+    The reason is the only thing that says *why* the send failed; collapsing it
+    to False leaves whoever reads the failed run guessing.
+    """
+    mock_resend.Emails.send.side_effect = Exception("domain example.com is not verified")
     settings = _make_settings(email_resend_api_key="re_test_key")
-    result = send_email("user@example.com", "Subject", "<p>Hi</p>", settings)
-    assert result is False
+
+    with pytest.raises(EmailSendError) as excinfo:
+        send_email("user@example.com", "Subject", "<p>Hi</p>", settings)
+
+    message = str(excinfo.value)
+    assert "resend" in message.lower()
+    assert "domain example.com is not verified" in message
+
+
+@patch("mycoach.email.sender.smtplib.SMTP")
+def test_send_email_smtp_failure_carries_the_backend_reason(mock_smtp_class: MagicMock) -> None:
+    """An SMTP rejection raises with the server's own words, like the Resend path."""
+    mock_smtp_class.side_effect = OSError("connection refused")
+    settings = _make_settings(email_resend_api_key="", email_smtp_host="smtp.example.com")
+
+    with pytest.raises(EmailSendError) as excinfo:
+        send_email("user@example.com", "Subject", "<p>Hi</p>", settings)
+
+    message = str(excinfo.value)
+    assert "smtp" in message.lower()
+    assert "connection refused" in message
 
 
 # --- Convenience sender functions ---

--- a/tests/test_scheduler/test_job_runs.py
+++ b/tests/test_scheduler/test_job_runs.py
@@ -12,6 +12,7 @@ import pytest
 from sqlalchemy import select
 
 from mycoach.coaching.exceptions import PipelineSkip
+from mycoach.email.sender import EmailSendError
 from mycoach.models.activity import Activity
 from mycoach.models.job_run import JobRun
 from mycoach.scheduler.jobs import (
@@ -549,6 +550,51 @@ async def test_rejected_send_fails_the_run_with_the_cause() -> None:
     assert runs[0].error is not None
     assert "daily briefing" in runs[0].error
     assert "email" in runs[0].error
+
+
+async def test_rejected_send_records_the_backend_reason() -> None:
+    """The backend's rejection reason survives into the run's error column.
+
+    The recorded error is the only durable account of a failure — a reader must
+    not have to go back to the logs to learn why the send was refused.
+    """
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch(
+            "mycoach.scheduler.jobs.send_daily_briefing",
+            side_effect=EmailSendError("resend rejected the message: domain not verified"),
+        ),
+    ):
+        await _record_run("daily_briefing", _daily_briefing())
+
+    runs = await _job_runs()
+    assert runs[0].status == "failed"
+    assert runs[0].email_delivered is False
+    assert runs[0].error is not None
+    assert "daily briefing" in runs[0].error
+    assert "domain not verified" in runs[0].error
+
+
+async def test_unattempted_send_records_the_configuration_cause() -> None:
+    """A send that never reached a backend says so, rather than "send failed".
+
+    ``False`` now means only "no backend was available to attempt this", which is
+    a configuration fault and must read as one.
+    """
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
+        patch("mycoach.scheduler.jobs.async_session", test_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_daily_briefing", return_value=False),
+    ):
+        await _record_run("daily_briefing", _daily_briefing())
+
+    runs = await _job_runs()
+    assert runs[0].status == "failed"
+    assert runs[0].error is not None
+    assert "backend" in runs[0].error
 
 
 async def test_delivery_appears_in_the_structured_log_line(


### PR DESCRIPTION
Closes #10.

Verifying the pipelines end to end turned up one thing the acceptance criteria could not be met without: a failed run's recorded error has to diagnose the failure unaided, and it did not. The backends caught the rejection, logged it, and returned False, so `JobRun.error` read only "daily briefing email send failed" — the reason lived in the logs, which is exactly the re-derivation the issue asks to avoid.

`_send_via_resend` / `_send_via_smtp` now raise `EmailSendError` carrying the backend's own words, and `send_email`'s False return narrows to mean only "no backend was available to attempt this" — a configuration fault, which `_deliver` now names as one. With that in place the induced failure records:

    daily briefing email send failed — Resend rejected the message:
    API key is invalid

The verification itself: all five jobs triggered through POST /api/system/scheduler/trigger/{job} against the real Garmin account and the live Resend backend, eight runs recorded, reconciled against the inbox — three runs reporting delivery, three messages arriving, matching to the second. PROGRESS.md carries the full account, including what the audit established and where the docs were wrong: Phase 7 was ticked complete having never sent a message, the roadmap's email-configuration item was false rather than merely unverified, and the March–July gap in coaching output was disuse, not a defect.