### PR TITLE
fix(logger): serve navigations stale-while-revalidate off-LAN

### DIFF
--- a/src/mycoach/static/logger/sw.js
+++ b/src/mycoach/static/logger/sw.js
@@ -43,10 +43,29 @@ self.addEventListener("fetch", (event) => {
     // API calls: always go to network (offline → the app queues locally).
     if (url.pathname.startsWith("/api/")) return;
 
-    // Navigations: network-first, fall back to the cached shell offline.
+    // Navigations: stale-while-revalidate. Off-LAN, the domain resolves to a
+    // private address unreachable from the mobile network — the connection
+    // hangs instead of rejecting, so a network-first `.catch()` never fires
+    // and the tab sits on a blank screen. Serving the cached shell first
+    // means the app opens immediately either way, and a reachable network
+    // still refreshes the cache in the background.
     if (req.mode === "navigate") {
+        const update = fetch(req)
+            .then((resp) => {
+                if (!resp.ok) return resp;
+                const copy = resp.clone();
+                return caches
+                    .open(CACHE)
+                    .then((c) => c.put("/logger", copy))
+                    .then(() => resp);
+            })
+            .catch(() => undefined);
+
+        event.waitUntil(update);
         event.respondWith(
-            fetch(req).catch(() => caches.match("/logger"))
+            caches.match("/logger").then((hit) =>
+                hit ? hit : update.then((resp) => resp || fetch(req))
+            )
         );
         return;
     }


### PR DESCRIPTION
## Summary
- Navigations were served network-first with a `.catch()` fallback to the cached shell, but off-LAN the domain resolves to a private address unreachable from the mobile network — the fetch hangs rather than rejects, so the catch never fires and the tab sits on a blank screen.
- Serve the cached shell immediately (stale-while-revalidate) and refresh it in the background instead, so the logger opens at once regardless of network reachability.
- Non-navigation request handling and the activate-time same-prefix cache purge are untouched.

## Test plan
- [ ] No JS test framework exists in this repo, so this was verified by reasoning through the control flow (warm cache/reachable network, warm cache/hanging network, cold cache/reachable network, cold cache/hanging network) rather than automated tests.
- [ ] Manual check recommended: open the logger once over the LAN to pick up the updated service worker, then confirm it opens instantly off-LAN (e.g. mobile data at the gym).

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)