### PR TITLE
Availability: standing schedule with per-week overrides

### DIFF
--- a/alembic/versions/a2b3c4d5e6f7_add_default_availability_and_plan_source.py
+++ b/alembic/versions/a2b3c4d5e6f7_add_default_availability_and_plan_source.py
@@ -1,0 +1,64 @@
+"""Add default_availability table and availability_source on weekly_plans
+
+Revision ID: a2b3c4d5e6f7
+Revises: f6a7b8c9d0e1
+Create Date: 2026-08-05 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a2b3c4d5e6f7'
+down_revision: Union[str, Sequence[str], None] = 'f6a7b8c9d0e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'default_availability',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('day_of_week', sa.Integer(), nullable=False),
+        sa.Column('sport', sa.String(length=50), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+    with op.batch_alter_table('weekly_plans', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('availability_source', sa.String(length=20), nullable=True))
+
+    # Seed the standing schedule from the most recently declared week, so the
+    # feature is live without a setup step. Picks the single latest week_start
+    # per user and copies its rows; a database with no declared weeks at all
+    # (or no users) seeds nothing, leaving an empty (still valid) default.
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO default_availability (user_id, day_of_week, sport)
+            SELECT wa.user_id, wa.day_of_week, wa.sport
+            FROM weekly_availabilities wa
+            INNER JOIN (
+                SELECT user_id, MAX(week_start) AS latest_week_start
+                FROM weekly_availabilities
+                GROUP BY user_id
+            ) latest
+                ON latest.user_id = wa.user_id
+                AND latest.latest_week_start = wa.week_start
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('weekly_plans', schema=None) as batch_op:
+        batch_op.drop_column('availability_source')
+
+    op.drop_table('default_availability')

--- a/src/mycoach/api/pages/availability.py
+++ b/src/mycoach/api/pages/availability.py
@@ -1,6 +1,7 @@
 """Availability input page — set weekly training availability slots."""
 
 from datetime import date, timedelta
+from typing import Any
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse
@@ -8,8 +9,9 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from mycoach.coaching.context import get_default_availability
 from mycoach.database import get_db
-from mycoach.models.availability import WeeklyAvailability
+from mycoach.models.availability import DefaultAvailability, WeeklyAvailability
 
 router = APIRouter(tags=["pages"])
 
@@ -35,9 +37,47 @@ def _next_monday(ref: date | None = None) -> date:
 async def availability_page(
     request: Request,
     session: AsyncSession = Depends(get_db),
-    week: str = Query("next", pattern="^(current|next)$"),
+    week: str = Query("next", pattern="^(current|next|default)$"),
 ) -> HTMLResponse:
-    """Render the availability input page for the selected week."""
+    """Render the availability input page for the selected week.
+
+    ``week=default`` renders the standing schedule (no dates — it has none).
+    ``week=next`` with no declared rows for that week pre-fills the form from
+    the standing schedule and marks each pre-filled day as coming from it;
+    this is display-only and writes nothing until the user saves.
+    """
+    templates: Jinja2Templates = request.app.state.templates
+
+    if week == "default":
+        default_slots = await get_default_availability(session, USER_ID)
+        slots_by_day: dict[int, DefaultAvailability | WeeklyAvailability] = {
+            slot.day_of_week: slot for slot in default_slots
+        }
+        week_days: list[dict[str, Any]] = [
+            {
+                "day_of_week": i,
+                "day_name": DAY_NAMES[i],
+                "date": None,
+                "slot": slots_by_day.get(i),
+                "from_default": False,
+            }
+            for i in range(7)
+        ]
+
+        return templates.TemplateResponse(
+            request,
+            "availability.html",
+            {
+                "active_page": "availability",
+                "week": week,
+                "week_label": "your standing schedule",
+                "week_start": None,
+                "week_start_str": "Standing schedule",
+                "week_end_str": "applies every week by default",
+                "week_days": week_days,
+            },
+        )
+
     current_mon = _current_monday()
     next_mon = _next_monday()
     target_monday = current_mon if week == "current" else next_mon
@@ -55,25 +95,33 @@ async def availability_page(
     existing_slots = list(result.scalars().all())
 
     # Build a lookup by day_of_week for pre-filling the form
-    slots_by_day: dict[int, WeeklyAvailability] = {}
-    for slot in existing_slots:
-        slots_by_day[slot.day_of_week] = slot
+    slots_by_day = {slot.day_of_week: slot for slot in existing_slots}
+
+    # A declared-empty week (only possible for "next") is pre-filled from the
+    # standing default, purely for display — nothing is written on this GET.
+    # Materialization only ever happens inside plan generation.
+    default_by_day: dict[int, DefaultAvailability] = {}
+    if week == "next" and not existing_slots:
+        default_slots = await get_default_availability(session, USER_ID)
+        default_by_day = {slot.day_of_week: slot for slot in default_slots}
 
     # Build week days with dates
     week_days = []
     for i in range(7):
         day_date = target_monday + timedelta(days=i)
         existing = slots_by_day.get(i)
+        from_default = existing is None and i in default_by_day
+        slot = existing if existing is not None else default_by_day.get(i)
         week_days.append(
             {
                 "day_of_week": i,
                 "day_name": DAY_NAMES[i],
                 "date": day_date,
-                "slot": existing,
+                "slot": slot,
+                "from_default": from_default,
             }
         )
 
-    templates: Jinja2Templates = request.app.state.templates
     return templates.TemplateResponse(
         request,
         "availability.html",

--- a/src/mycoach/api/routes/availability.py
+++ b/src/mycoach/api/routes/availability.py
@@ -6,10 +6,13 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from mycoach.coaching.context import get_default_availability as fetch_default_availability
 from mycoach.database import get_db
-from mycoach.models.availability import WeeklyAvailability
+from mycoach.models.availability import DefaultAvailability, WeeklyAvailability
 from mycoach.schemas.availability import (
     AvailabilitySlot,
+    DefaultAvailabilityRead,
+    DefaultAvailabilityReplace,
     WeeklyAvailabilityCreate,
     WeeklyAvailabilityRead,
 )
@@ -77,6 +80,40 @@ async def get_next_week_availability(
     )
     result = await session.execute(stmt)
     return list(result.scalars().all())
+
+
+@router.get("/default", response_model=list[DefaultAvailabilityRead])
+async def get_default_availability(
+    session: AsyncSession = Depends(get_db),
+) -> list[DefaultAvailability]:
+    """Get the standing weekly schedule. An empty list is a valid state."""
+    return await fetch_default_availability(session, USER_ID)
+
+
+@router.post("/default", response_model=list[DefaultAvailabilityRead], status_code=201)
+async def set_default_availability(
+    body: DefaultAvailabilityReplace,
+    session: AsyncSession = Depends(get_db),
+) -> list[DefaultAvailability]:
+    """Replace the standing weekly schedule. An empty slot list clears it."""
+    await session.execute(
+        delete(DefaultAvailability).where(DefaultAvailability.user_id == USER_ID)
+    )
+
+    rows = []
+    for slot in body.slots:
+        row = DefaultAvailability(
+            user_id=USER_ID,
+            day_of_week=slot.day_of_week,
+            sport=slot.sport,
+        )
+        session.add(row)
+        rows.append(row)
+
+    await session.commit()
+    for row in rows:
+        await session.refresh(row)
+    return rows
 
 
 @router.get("/{week_start}", response_model=list[WeeklyAvailabilityRead])

--- a/src/mycoach/coaching/context.py
+++ b/src/mycoach/coaching/context.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from mycoach.coaching.prompt_builder import activity_to_dict, snapshot_to_dict
 from mycoach.models.activity import Activity, GymWorkoutDetail
-from mycoach.models.availability import WeeklyAvailability
+from mycoach.models.availability import DefaultAvailability, WeeklyAvailability
 from mycoach.models.coaching import MesocycleConfig
 from mycoach.models.health import DailyHealthSnapshot
 from mycoach.models.plan import PlannedSession, WeeklyPlan
@@ -95,6 +95,19 @@ async def get_availability_for_week(
         }
         for s in slots
     ]
+
+
+async def get_default_availability(
+    session: AsyncSession, user_id: int
+) -> list[DefaultAvailability]:
+    """Get the user's standing weekly schedule, ordered by day. May be empty."""
+    stmt = (
+        select(DefaultAvailability)
+        .where(DefaultAvailability.user_id == user_id)
+        .order_by(DefaultAvailability.day_of_week)
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
 
 
 async def get_mesocycle_context(session: AsyncSession, user_id: int) -> str | None:

--- a/src/mycoach/coaching/engine.py
+++ b/src/mycoach/coaching/engine.py
@@ -14,6 +14,7 @@ from mycoach.coaching.context import (
     get_activities_for_week,
     get_activity_with_details,
     get_availability_for_week,
+    get_default_availability,
     get_gym_details_for_week,
     get_gym_performance_history,
     get_health_trends,
@@ -29,7 +30,7 @@ from mycoach.coaching.context import (
     get_today_planned_sessions,
     link_activity_to_planned_session,
 )
-from mycoach.coaching.exceptions import PipelineSkip
+from mycoach.coaching.exceptions import NoAvailabilityConfigured, PipelineSkip
 from mycoach.coaching.llm_client import LLMClient, LLMResponse, get_llm_client
 from mycoach.coaching.prompt_builder import (
     build_cardio_plan_prompt,
@@ -47,6 +48,7 @@ from mycoach.coaching.response_parser import (
     WeeklyRecapResponse,
     parse_response,
 )
+from mycoach.models.availability import WeeklyAvailability
 from mycoach.models.coaching import CoachingInsight
 from mycoach.models.plan import PlannedSession, WeeklyPlan
 from mycoach.models.prompt_log import PromptLog
@@ -231,6 +233,47 @@ class CoachingEngine:
 
         return llm_response, parsed, error_msg
 
+    async def _materialize_availability(
+        self, session: AsyncSession, user_id: int, week_start: date
+    ) -> str:
+        """Ensure ``week_start`` has availability rows, materializing from the
+        standing default schedule if none were declared.
+
+        This is the single seam every weekly-plan generation path passes
+        through, so the scheduled run and manual regenerate can't disagree
+        about what the week's availability is. Returns ``"declared"`` if the
+        week already had rows, ``"default"`` if rows were copied in from
+        ``DefaultAvailability``. Raises ``NoAvailabilityConfigured`` if the
+        week has no rows and the default is also empty — nothing is written
+        in that case.
+        """
+        existing = await session.execute(
+            select(WeeklyAvailability.id).where(
+                WeeklyAvailability.user_id == user_id,
+                WeeklyAvailability.week_start == week_start,
+            )
+        )
+        if existing.first() is not None:
+            return "declared"
+
+        default_slots = await get_default_availability(session, user_id)
+        if not default_slots:
+            raise NoAvailabilityConfigured(
+                f"No availability configured for week of {week_start}"
+            )
+
+        for slot in default_slots:
+            session.add(
+                WeeklyAvailability(
+                    user_id=user_id,
+                    week_start=week_start,
+                    day_of_week=slot.day_of_week,
+                    sport=slot.sport,
+                )
+            )
+        await session.flush()
+        return "default"
+
     async def generate_weekly_plan(
         self,
         session: AsyncSession,
@@ -268,9 +311,8 @@ class CoachingEngine:
                 raise PipelineSkip(f"Active plan already exists for week of {week_start}")
 
         # 1. Gather shared context
+        availability_source = await self._materialize_availability(session, user_id, week_start)
         availability = await get_availability_for_week(session, user_id, week_start)
-        if not availability:
-            raise PipelineSkip(f"No availability slots set for week of {week_start}")
         logger.info(
             "Availability for week %s: %s",
             week_start,
@@ -303,6 +345,7 @@ class CoachingEngine:
             week_start=week_start,
             prompt_version=PROMPT_VERSION,
             status="active",
+            availability_source=availability_source,
         )
         session.add(plan)
         await session.flush()

--- a/src/mycoach/coaching/exceptions.py
+++ b/src/mycoach/coaching/exceptions.py
@@ -11,3 +11,12 @@ class PipelineSkip(Exception):  # noqa: N818 - a skip is deliberately not an err
     LLM response, whose ``json.JSONDecodeError`` is a ``ValueError`` subtype)
     from being mistaken for a routine skip.
     """
+
+
+class NoAvailabilityConfigured(PipelineSkip):
+    """Raised when a week has no declared availability and no standing default.
+
+    Distinguished from a plain ``PipelineSkip`` so callers can react to it
+    specifically (e.g. sending a "we couldn't plan your week" email) without
+    parsing the skip message.
+    """

--- a/src/mycoach/email/sender.py
+++ b/src/mycoach/email/sender.py
@@ -135,6 +135,11 @@ def _dashboard_url(settings: Settings) -> str:
     return f"{settings.app_base_url}/dashboard"
 
 
+def _default_schedule_url(settings: Settings) -> str:
+    """Build the link straight to the standing-schedule tab of the availability page."""
+    return f"{settings.app_base_url}/availability?week=default"
+
+
 def _send_via_resend(settings: Settings, to: str, subject: str, html: str) -> None:
     """Send email using Resend API.
 
@@ -227,9 +232,16 @@ def send_weekly_plan(
     summary: str,
     sessions: list[dict],
     week_start: str,
+    availability_source: str | None = None,
     settings: Settings | None = None,  # type: ignore[type-arg]
 ) -> bool:
-    """Send the weekly training plan email."""
+    """Send the weekly training plan email.
+
+    ``availability_source`` is ``"declared"`` or ``"default"`` (or None for plans
+    generated before the standing-schedule feature existed). When ``"default"``,
+    the email tells the reader the week was planned against their default
+    schedule rather than something they set.
+    """
     if settings is None:
         settings = get_settings()
     display_sessions = [
@@ -241,10 +253,26 @@ def send_weekly_plan(
             "summary": summary,
             "sessions": display_sessions,
             "week_start": week_start,
+            "availability_source": availability_source,
             "dashboard_url": _dashboard_url(settings),
+            "default_schedule_url": _default_schedule_url(settings),
         },
     )
     return send_email(settings.email_to, "MyCoach — Weekly Plan", html, settings)
+
+
+def send_no_availability(week_start: str, settings: Settings | None = None) -> bool:  # type: ignore[type-arg]
+    """Send the "no plan generated" email for a week with no declared or default availability."""
+    if settings is None:
+        settings = get_settings()
+    html = _render_template(
+        "no_availability.html",
+        {
+            "week_start": week_start,
+            "default_schedule_url": _default_schedule_url(settings),
+        },
+    )
+    return send_email(settings.email_to, "MyCoach — No Plan Generated", html, settings)
 
 
 def send_post_workout(content: dict, activity_title: str, settings: Settings | None = None) -> bool:  # type: ignore[type-arg]

--- a/src/mycoach/email/templates/no_availability.html
+++ b/src/mycoach/email/templates/no_availability.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}No Plan Generated{% endblock %}
+{% block subtitle %}No plan generated{% endblock %}
+{% block content %}
+
+<!-- Hero -->
+<tr>
+  <td class="px" style="padding-top:26px;padding-bottom:18px;">
+    <div class="eyebrow">Week of {{ week_start }}</div>
+    <div class="verdict" style="font-size:32px;margin-top:10px;">No plan generated</div>
+    <div class="rule" style="margin-top:16px;">&nbsp;</div>
+    <div class="lead" style="margin-top:14px;">
+      No plan was generated for the week of {{ week_start }} because you don't have a standing
+      schedule set, and you didn't declare that week either. MyCoach won't invent a training week
+      for you — set your default schedule and it'll plan every week from there automatically.
+    </div>
+  </td>
+</tr>
+
+<tr>
+  <td class="px" style="padding-top:22px;padding-bottom:28px;">
+    <a href="{{ default_schedule_url|default('#') }}" class="cta">Set your standing schedule &rarr;</a>
+  </td>
+</tr>
+{% endblock %}

--- a/src/mycoach/email/templates/weekly_plan.html
+++ b/src/mycoach/email/templates/weekly_plan.html
@@ -13,6 +13,11 @@
     {% if summary %}
     <div class="lead" style="margin-top:14px;">{{ summary }}</div>
     {% endif %}
+    {% if availability_source == 'default' %}
+    <div class="coach" style="margin-top:16px;padding:12px 14px;">
+      <div class="coach-t">Planned against your standing schedule — you didn't set this week, so it was filled in from your default. <a href="{{ default_schedule_url|default('#') }}">Change it here</a> if that's wrong.</div>
+    </div>
+    {% endif %}
   </td>
 </tr>
 

--- a/src/mycoach/models/__init__.py
+++ b/src/mycoach/models/__init__.py
@@ -1,5 +1,5 @@
 from mycoach.models.activity import Activity, GymWorkoutDetail
-from mycoach.models.availability import WeeklyAvailability
+from mycoach.models.availability import DefaultAvailability, WeeklyAvailability
 from mycoach.models.coaching import CoachingInsight, MesocycleConfig
 from mycoach.models.data_source import DataSourceConfig
 from mycoach.models.health import DailyHealthSnapshot
@@ -15,6 +15,7 @@ __all__ = [
     "CoachingInsight",
     "DailyHealthSnapshot",
     "DataSourceConfig",
+    "DefaultAvailability",
     "GymWorkoutDetail",
     "JobRun",
     "MesocycleConfig",

--- a/src/mycoach/models/availability.py
+++ b/src/mycoach/models/availability.py
@@ -15,3 +15,14 @@ class WeeklyAvailability(Base):
     day_of_week: Mapped[int]  # 0=Monday, 6=Sunday
     # sport: one of gym/swimming/running/padel; nullable for backward compat
     sport: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+
+class DefaultAvailability(Base):
+    """The user's standing weekly schedule, used to seed a week with no declared rows."""
+
+    __tablename__ = "default_availability"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    day_of_week: Mapped[int]  # 0=Monday, 6=Sunday
+    sport: Mapped[str | None] = mapped_column(String(50), nullable=True)

--- a/src/mycoach/models/plan.py
+++ b/src/mycoach/models/plan.py
@@ -23,6 +23,10 @@ class WeeklyPlan(Base):
     )  # draft, active, completed, superseded
     summary: Mapped[str | None] = mapped_column(Text, default=None)
     raw_llm_output: Mapped[str | None] = mapped_column(Text, default=None)
+    # "declared" if the week's availability was set by the user, "default" if
+    # materialised from the standing schedule. Null for plans generated before
+    # this column existed.
+    availability_source: Mapped[str | None] = mapped_column(String(20), default=None)
     created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
 
 

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -18,12 +18,13 @@ from functools import partial
 from sqlalchemy import select
 
 from mycoach.coaching.engine import CoachingEngine
-from mycoach.coaching.exceptions import PipelineSkip
+from mycoach.coaching.exceptions import NoAvailabilityConfigured, PipelineSkip
 from mycoach.config import get_settings
 from mycoach.database import async_session
 from mycoach.email.sender import (
     EmailSendError,
     send_daily_briefing,
+    send_no_availability,
     send_post_workout,
     send_weekly_plan,
     send_weekly_recap,
@@ -254,7 +255,18 @@ async def _weekly_plan() -> None:
     next_monday = today + timedelta(days=days_until_monday)
 
     async with async_session() as session:
-        plan = await engine.generate_weekly_plan(session, USER_ID, next_monday)
+        try:
+            plan = await engine.generate_weekly_plan(session, USER_ID, next_monday)
+        except NoAvailabilityConfigured:
+            # Caught here, before it propagates to _record_run, so the "we
+            # couldn't plan your week" email can still go out — the skip is
+            # re-raised afterwards so the run is recorded as skipped as usual.
+            if await _get_user_email_pref("email_weekly_plan"):
+                _deliver(
+                    partial(send_no_availability, week_start=str(next_monday)),
+                    "no-availability",
+                )
+            raise
         logger.info("Scheduler: weekly plan generated for %s", next_monday)
 
         if await _get_user_email_pref("email_weekly_plan"):
@@ -281,6 +293,7 @@ async def _weekly_plan() -> None:
                     summary=plan.summary or "",
                     sessions=session_dicts,
                     week_start=str(next_monday),
+                    availability_source=plan.availability_source,
                 ),
                 "weekly plan",
             )

--- a/src/mycoach/schemas/__init__.py
+++ b/src/mycoach/schemas/__init__.py
@@ -6,6 +6,9 @@ from mycoach.schemas.activity import (
 )
 from mycoach.schemas.availability import (
     AvailabilitySlot,
+    DefaultAvailabilityRead,
+    DefaultAvailabilityReplace,
+    DefaultAvailabilitySlot,
     WeeklyAvailabilityCreate,
     WeeklyAvailabilityRead,
 )
@@ -64,6 +67,9 @@ __all__ = [
     "DataSourceStatus",
     "DailyHealthSnapshotCreate",
     "DailyHealthSnapshotRead",
+    "DefaultAvailabilityRead",
+    "DefaultAvailabilityReplace",
+    "DefaultAvailabilitySlot",
     "GymWorkoutDetailCreate",
     "GymWorkoutDetailRead",
     "MesocycleConfigCreate",

--- a/src/mycoach/schemas/availability.py
+++ b/src/mycoach/schemas/availability.py
@@ -24,3 +24,21 @@ class WeeklyAvailabilityRead(BaseModel):
     sport: str | None = None  # nullable for backward compat with existing rows
 
     model_config = {"from_attributes": True}
+
+
+class DefaultAvailabilitySlot(BaseModel):
+    day_of_week: int = Field(ge=0, le=6)
+    sport: SportType | None = None  # None means "no training" on this day
+
+
+class DefaultAvailabilityReplace(BaseModel):
+    slots: list[DefaultAvailabilitySlot]
+
+
+class DefaultAvailabilityRead(BaseModel):
+    id: int
+    user_id: int
+    day_of_week: int
+    sport: str | None = None
+
+    model_config = {"from_attributes": True}

--- a/src/mycoach/templates/availability.html
+++ b/src/mycoach/templates/availability.html
@@ -21,11 +21,22 @@
             {% if week == 'next' %}bg-accent text-ink{% else %}bg-surface text-zinc-400 hover:bg-surface-raised{% endif %}">
             Next Week
         </a>
+        <a href="/availability?week=default"
+            class="flex-1 text-center py-2 text-sm font-medium transition-colors border-l border-white/[0.10]
+            {% if week == 'default' %}bg-accent text-ink{% else %}bg-surface text-zinc-400 hover:bg-surface-raised{% endif %}">
+            Default
+        </a>
     </div>
 
+    {% if week == 'default' %}
+    <p class="text-sm text-zinc-400">
+        This is your standing schedule. Weeks you don't declare are planned from it automatically.
+    </p>
+    {% else %}
     <p class="text-sm text-zinc-400">
         Select the days you can train {{ week_label }} and the sport for each session.
     </p>
+    {% endif %}
 
     <!-- Availability form -->
     <form id="availability-form" method="post" class="space-y-3" hx-boost="false">
@@ -40,9 +51,16 @@
                     <div class="flex items-center gap-3 flex-1">
                         <div class="w-10 text-center">
                             <p class="text-[10px] uppercase font-semibold tracking-[0.1em] text-zinc-500">{{ day.day_name[:3] }}</p>
+                            {% if day.date %}
                             <p class="text-lg font-bold font-mono text-zinc-300">{{ day.date.day }}</p>
+                            {% else %}
+                            <p class="text-lg font-bold font-mono text-zinc-600">&mdash;</p>
+                            {% endif %}
                         </div>
                         <span class="font-medium text-zinc-100">{{ day.day_name }}</span>
+                        {% if day.from_default %}
+                        <span class="text-[10px] font-semibold uppercase tracking-wide text-accent/80 border border-accent/30 rounded-full px-2 py-0.5">From default</span>
+                        {% endif %}
                     </div>
                 </label>
 
@@ -52,6 +70,12 @@
                         <label class="block text-[11px] font-medium text-zinc-500 uppercase tracking-wide mb-1">Sport</label>
                         <select name="day_{{ day.day_of_week }}_sport"
                             class="w-full rounded-lg text-sm px-2 py-1.5">
+                            {% if week == 'default' %}
+                            <option value=""
+                                {% if day.slot and not day.slot.sport %}selected{% endif %}>
+                                No training
+                            </option>
+                            {% endif %}
                             {% for sport in ['gym', 'swimming', 'running', 'padel'] %}
                             <option value="{{ sport }}"
                                 {% if day.slot and day.slot.sport == sport %}selected{% endif %}
@@ -97,6 +121,8 @@
     form.addEventListener('submit', function(e) {
         e.preventDefault();
 
+        var isDefault = {{ 'true' if week == 'default' else 'false' }};
+
         var slots = [];
         for (var day = 0; day < 7; day++) {
             var cb = form.querySelector('[name="day_' + day + '_enabled"]');
@@ -104,20 +130,22 @@
                 var sportVal = form.querySelector('[name="day_' + day + '_sport"]').value;
                 slots.push({
                     day_of_week: day,
-                    sport: sportVal
+                    sport: (isDefault && sportVal === '') ? null : sportVal
                 });
             }
         }
 
-        var weekStart = '{{ week_start.isoformat() }}';
-        var payload = { week_start: weekStart, slots: slots };
+        var url = isDefault ? '/api/availability/default' : '/api/availability';
+        var payload = isDefault
+            ? { slots: slots }
+            : { week_start: '{{ week_start.isoformat() if week_start else "" }}', slots: slots };
 
         var resultDiv = document.getElementById('save-result');
         var btn = document.getElementById('save-btn');
         btn.disabled = true;
         btn.textContent = 'Saving...';
 
-        fetch('/api/availability', {
+        fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)

--- a/tests/test_api/test_availability.py
+++ b/tests/test_api/test_availability.py
@@ -211,3 +211,79 @@ async def test_delete_slot(client: AsyncClient) -> None:
 async def test_delete_slot_not_found(client: AsyncClient) -> None:
     resp = await client.delete("/api/availability/999")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_default_availability_empty_is_valid(client: AsyncClient) -> None:
+    resp = await client.get("/api/availability/default")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_set_default_availability(client: AsyncClient) -> None:
+    async with test_session() as session:
+        await _create_user(session)
+
+    resp = await client.post(
+        "/api/availability/default",
+        json={
+            "slots": [
+                {"day_of_week": 0, "sport": "gym"},
+                {"day_of_week": 1, "sport": "swimming"},
+                {"day_of_week": 2, "sport": None},
+            ],
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert len(data) == 3
+    assert data[0]["day_of_week"] == 0
+    assert data[0]["sport"] == "gym"
+    assert data[2]["day_of_week"] == 2
+    assert data[2]["sport"] is None
+
+    get_resp = await client.get("/api/availability/default")
+    assert get_resp.status_code == 200
+    assert len(get_resp.json()) == 3
+
+
+@pytest.mark.asyncio
+async def test_set_default_availability_replaces_existing(client: AsyncClient) -> None:
+    async with test_session() as session:
+        await _create_user(session)
+
+    await client.post(
+        "/api/availability/default",
+        json={"slots": [{"day_of_week": 0, "sport": "gym"}]},
+    )
+
+    resp = await client.post(
+        "/api/availability/default",
+        json={"slots": [{"day_of_week": 3, "sport": "padel"}]},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["day_of_week"] == 3
+
+    get_resp = await client.get("/api/availability/default")
+    assert len(get_resp.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_set_default_availability_empty_clears_it(client: AsyncClient) -> None:
+    async with test_session() as session:
+        await _create_user(session)
+
+    await client.post(
+        "/api/availability/default",
+        json={"slots": [{"day_of_week": 0, "sport": "gym"}]},
+    )
+
+    resp = await client.post("/api/availability/default", json={"slots": []})
+    assert resp.status_code == 201
+    assert resp.json() == []
+
+    get_resp = await client.get("/api/availability/default")
+    assert get_resp.json() == []

--- a/tests/test_email/test_sender.py
+++ b/tests/test_email/test_sender.py
@@ -12,6 +12,7 @@ from mycoach.email.sender import (
     _render_template,
     send_daily_briefing,
     send_email,
+    send_no_availability,
     send_post_workout,
     send_weekly_plan,
     send_weekly_recap,
@@ -325,6 +326,64 @@ def test_send_weekly_plan_calls_send_email(mock_send: MagicMock) -> None:
     )
     assert result is True
     mock_send.assert_called_once()
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_send_weekly_plan_includes_default_line_when_planned_from_default(
+    mock_send: MagicMock,
+) -> None:
+    """The 'planned from your standing schedule' line shows when availability_source is default."""
+    settings = _make_settings()
+    send_weekly_plan(
+        summary="Good week",
+        sessions=[],
+        week_start="2025-03-03",
+        availability_source="default",
+        settings=settings,
+    )
+    html = mock_send.call_args[0][2]
+    assert "standing schedule" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_send_weekly_plan_omits_default_line_when_declared(mock_send: MagicMock) -> None:
+    """The default-schedule line is omitted when the week was declared by the user."""
+    settings = _make_settings()
+    send_weekly_plan(
+        summary="Good week",
+        sessions=[],
+        week_start="2025-03-03",
+        availability_source="declared",
+        settings=settings,
+    )
+    html = mock_send.call_args[0][2]
+    assert "standing schedule" not in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_send_weekly_plan_omits_default_line_when_source_unknown(mock_send: MagicMock) -> None:
+    """Plans generated before availability_source existed (None) don't show the line."""
+    settings = _make_settings()
+    send_weekly_plan(
+        summary="Good week", sessions=[], week_start="2025-03-03", settings=settings
+    )
+    html = mock_send.call_args[0][2]
+    assert "standing schedule" not in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_send_no_availability_names_the_week_and_links_default_schedule(
+    mock_send: MagicMock,
+) -> None:
+    """The no-availability email names the week and links straight to the default tab."""
+    settings = _make_settings(app_base_url="https://coach.example.com")
+    result = send_no_availability(week_start="2025-03-03", settings=settings)
+    assert result is True
+    html = mock_send.call_args[0][2]
+    subject = mock_send.call_args[0][1]
+    assert "No Plan Generated" in subject
+    assert "2025-03-03" in html
+    assert "https://coach.example.com/availability?week=default" in html
 
 
 @patch("mycoach.email.sender.send_email", return_value=True)

--- a/tests/test_migrations/test_default_availability_seed.py
+++ b/tests/test_migrations/test_default_availability_seed.py
@@ -1,0 +1,122 @@
+"""Tests for the default_availability seed migration (a2b3c4d5e6f7)."""
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _alembic_config(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:
+    # alembic/env.py always overrides sqlalchemy.url from mycoach.config.get_settings(),
+    # so the DB target has to be steered via the same env var the app reads.
+    monkeypatch.setenv("MYCOACH_DB_URL", f"sqlite+aiosqlite:///{db_path}")
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    return cfg
+
+
+def _seed_user_and_availability(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        now = datetime.utcnow().isoformat()
+        cur.execute(
+            "INSERT INTO users "
+            "(id, name, email, fitness_level, created_at, updated_at, "
+            "email_daily_briefing, email_weekly_plan, email_post_workout, "
+            "email_sleep_coaching, email_weekly_recap) "
+            "VALUES (1, 'A', 'a@b.com', 'intermediate', ?, ?, 0, 0, 0, 0, 0)",
+            (now, now),
+        )
+        # An earlier one-off reshuffle, followed by the actual standing pattern.
+        rows = [
+            (1, "2026-03-09", 0, "padel"),
+            (1, "2026-07-13", 0, "gym"),
+            (1, "2026-07-13", 1, "swimming"),
+            (1, "2026-07-13", 2, "gym"),
+            (1, "2026-07-13", 3, "swimming"),
+            (1, "2026-07-13", 6, "running"),
+        ]
+        cur.executemany(
+            "INSERT INTO weekly_availabilities (user_id, week_start, day_of_week, sport) "
+            "VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_seed_uses_most_recently_declared_week(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "seed.db"
+    cfg = _alembic_config(db_path, monkeypatch)
+
+    command.upgrade(cfg, "f6a7b8c9d0e1")
+    _seed_user_and_availability(db_path)
+    command.upgrade(cfg, "a2b3c4d5e6f7")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT day_of_week, sport FROM default_availability WHERE user_id = 1 "
+            "ORDER BY day_of_week"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [
+        (0, "gym"),
+        (1, "swimming"),
+        (2, "gym"),
+        (3, "swimming"),
+        (6, "running"),
+    ]
+
+
+def test_seed_with_no_declared_weeks_is_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "empty.db"
+    cfg = _alembic_config(db_path, monkeypatch)
+
+    command.upgrade(cfg, "head")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT * FROM default_availability").fetchall()
+    finally:
+        conn.close()
+
+    assert rows == []
+
+
+def test_downgrade_drops_table_and_column(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "downgrade.db"
+    cfg = _alembic_config(db_path, monkeypatch)
+
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "f6a7b8c9d0e1")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(weekly_plans)").fetchall()}
+    finally:
+        conn.close()
+
+    assert "default_availability" not in tables
+    assert "availability_source" not in columns

--- a/tests/test_pages/test_availability.py
+++ b/tests/test_pages/test_availability.py
@@ -5,7 +5,9 @@ from datetime import date, timedelta
 import pytest
 from httpx import AsyncClient
 
-from mycoach.models.availability import WeeklyAvailability
+import re
+
+from mycoach.models.availability import DefaultAvailability, WeeklyAvailability
 from mycoach.models.user import User
 from tests.conftest import test_session
 
@@ -120,3 +122,101 @@ async def test_availability_page_has_save_button(client: AsyncClient) -> None:
     resp = await client.get("/availability")
     assert resp.status_code == 200
     assert "Save Availability" in resp.text
+
+
+async def test_availability_page_current_week_unchanged_when_empty(client: AsyncClient) -> None:
+    """The current-week tab keeps today's behaviour: no pre-fill from the default."""
+    await _seed_user()
+    async with test_session() as session:
+        session.add(DefaultAvailability(user_id=1, day_of_week=0, sport="gym"))
+        await session.commit()
+
+    resp = await client.get("/availability?week=current")
+    assert resp.status_code == 200
+    day0_cb = re.search(r'name="day_0_enabled"[^>]*', resp.text)
+    assert day0_cb is not None
+    assert "checked" not in day0_cb.group(0)
+    assert "From default" not in resp.text
+
+
+async def test_availability_page_next_week_prefills_from_default(client: AsyncClient) -> None:
+    """An empty next week pre-fills from the default and marks it as such."""
+    await _seed_user()
+    next_mon = _next_monday()
+    async with test_session() as session:
+        session.add(DefaultAvailability(user_id=1, day_of_week=0, sport="gym"))
+        await session.commit()
+
+    resp = await client.get("/availability?week=next")
+    assert resp.status_code == 200
+    html = resp.text
+    day0_cb = re.search(r'name="day_0_enabled"[^>]*', html)
+    assert day0_cb is not None
+    assert "checked" in day0_cb.group(0)
+    assert "From default" in html
+
+    # Purely display — nothing was written for the week.
+    async with test_session() as session:
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(WeeklyAvailability).where(
+                WeeklyAvailability.user_id == 1,
+                WeeklyAvailability.week_start == next_mon,
+            )
+        )
+        assert result.scalars().first() is None
+
+
+async def test_availability_page_next_week_declared_not_marked_as_default(
+    client: AsyncClient,
+) -> None:
+    """A declared next week renders its own rows, not marked as coming from the default."""
+    await _seed_user()
+    next_mon = _next_monday()
+    async with test_session() as session:
+        session.add(DefaultAvailability(user_id=1, day_of_week=0, sport="gym"))
+        session.add(
+            WeeklyAvailability(user_id=1, week_start=next_mon, day_of_week=0, sport="padel")
+        )
+        await session.commit()
+
+    resp = await client.get("/availability?week=next")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "From default" not in html
+    day0_select = re.search(r'name="day_0_sport".*?</select>', html, re.DOTALL)
+    assert day0_select is not None
+    padel_option = re.search(r'<option value="padel"[^>]*>', day0_select.group(0))
+    assert padel_option is not None
+    assert "selected" in padel_option.group(0)
+
+
+async def test_availability_page_default_tab_renders_prefilled(client: AsyncClient) -> None:
+    """The default tab renders the standing schedule, pre-filled from DefaultAvailability."""
+    await _seed_user()
+    async with test_session() as session:
+        session.add(DefaultAvailability(user_id=1, day_of_week=0, sport="gym"))
+        session.add(DefaultAvailability(user_id=1, day_of_week=2, sport=None))
+        await session.commit()
+
+    resp = await client.get("/availability?week=default")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "Standing schedule" in html
+    day0_cb = re.search(r'name="day_0_enabled"[^>]*', html)
+    assert day0_cb is not None
+    assert "checked" in day0_cb.group(0)
+    day2_cb = re.search(r'name="day_2_enabled"[^>]*', html)
+    assert day2_cb is not None
+    assert "checked" in day2_cb.group(0)
+    day6_cb = re.search(r'name="day_6_enabled"[^>]*', html)
+    assert day6_cb is not None
+    assert "checked" not in day6_cb.group(0)
+
+
+async def test_availability_page_default_tab_empty_is_valid(client: AsyncClient) -> None:
+    """An empty default is a valid, renderable state."""
+    resp = await client.get("/availability?week=default")
+    assert resp.status_code == 200
+    assert "Standing schedule" in resp.text

--- a/tests/test_plans/test_engine.py
+++ b/tests/test_plans/test_engine.py
@@ -8,9 +8,9 @@ import pytest
 from sqlalchemy import select
 
 from mycoach.coaching.engine import CoachingEngine
-from mycoach.coaching.exceptions import PipelineSkip
+from mycoach.coaching.exceptions import NoAvailabilityConfigured, PipelineSkip
 from mycoach.coaching.llm_client import LLMResponse
-from mycoach.models.availability import WeeklyAvailability
+from mycoach.models.availability import DefaultAvailability, WeeklyAvailability
 from mycoach.models.plan import PlannedSession
 from mycoach.models.prompt_log import PromptLog
 from mycoach.models.routine import RoutineDay, RoutineExercise, WorkoutRoutine
@@ -277,6 +277,7 @@ class TestGenerateWeeklyPlan:
                 await engine.generate_weekly_plan(session, user_id, week_start)
 
     async def test_no_availability_raises(self) -> None:
+        """No declared rows and no standing default raises the distinct skip subtype."""
         async with test_session() as session:
             user = User(email="test@example.com", name="Test", fitness_level="beginner")
             session.add(user)
@@ -286,8 +287,100 @@ class TestGenerateWeeklyPlan:
             mock_llm = _mock_llm_client()
             engine = CoachingEngine(llm_client=mock_llm)
 
-            with pytest.raises(PipelineSkip, match="No availability"):
+            with pytest.raises(NoAvailabilityConfigured, match="No availability"):
                 await engine.generate_weekly_plan(session, user.id, date(2024, 6, 10))
+
+            result = await session.execute(
+                select(WeeklyAvailability).where(WeeklyAvailability.user_id == user.id)
+            )
+            assert result.scalars().first() is None
+
+    async def test_declared_week_is_not_materialized_from_default(self) -> None:
+        """A week with declared rows is planned as-is; nothing is written to defaults."""
+        async with test_session() as session:
+            user_id, week_start = await _setup_user_and_availability(session)
+            session.add(DefaultAvailability(user_id=user_id, day_of_week=1, sport="gym"))
+            await session.commit()
+
+            mock_llm = _mock_llm_client()
+            engine = CoachingEngine(llm_client=mock_llm)
+            plan = await engine.generate_weekly_plan(session, user_id, week_start)
+
+            assert plan.availability_source == "declared"
+
+            result = await session.execute(
+                select(WeeklyAvailability).where(WeeklyAvailability.user_id == user_id)
+            )
+            days = sorted(s.day_of_week for s in result.scalars().all())
+            # Only the two originally declared slots — no top-up from the default.
+            assert days == [0, 3]
+
+    async def test_empty_week_materializes_from_default(self) -> None:
+        """An empty week with a populated default gets the default's rows copied in."""
+        async with test_session() as session:
+            user = User(email="test@example.com", name="Test", fitness_level="beginner")
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+
+            default_slots = [
+                DefaultAvailability(user_id=user.id, day_of_week=0, sport="gym"),
+                DefaultAvailability(user_id=user.id, day_of_week=1, sport="swimming"),
+                DefaultAvailability(user_id=user.id, day_of_week=6, sport="running"),
+            ]
+            for slot in default_slots:
+                session.add(slot)
+            await session.commit()
+
+            week_start = date(2024, 6, 10)
+            mock_llm = _mock_llm_client()
+            engine = CoachingEngine(llm_client=mock_llm)
+            plan = await engine.generate_weekly_plan(session, user.id, week_start)
+
+            assert plan.availability_source == "default"
+
+            result = await session.execute(
+                select(WeeklyAvailability)
+                .where(
+                    WeeklyAvailability.user_id == user.id,
+                    WeeklyAvailability.week_start == week_start,
+                )
+                .order_by(WeeklyAvailability.day_of_week)
+            )
+            rows = result.scalars().all()
+            assert [(r.day_of_week, r.sport) for r in rows] == [
+                (0, "gym"),
+                (1, "swimming"),
+                (6, "running"),
+            ]
+
+    async def test_materializing_does_not_disturb_adjacent_week(self) -> None:
+        """Materializing one week leaves an adjacent week's declared rows untouched."""
+        async with test_session() as session:
+            user_id, declared_week = await _setup_user_and_availability(session)
+            session.add(
+                DefaultAvailability(user_id=user_id, day_of_week=2, sport="padel")
+            )
+            await session.commit()
+
+            other_week = date(2024, 6, 17)  # the following Monday, undeclared
+            mock_llm = _mock_llm_client()
+            engine = CoachingEngine(llm_client=mock_llm)
+            await engine.generate_weekly_plan(session, user_id, other_week)
+
+            result = await session.execute(
+                select(WeeklyAvailability)
+                .where(
+                    WeeklyAvailability.user_id == user_id,
+                    WeeklyAvailability.week_start == declared_week,
+                )
+                .order_by(WeeklyAvailability.day_of_week)
+            )
+            rows = result.scalars().all()
+            assert [(r.day_of_week, r.sport) for r in rows] == [
+                (0, "running"),
+                (3, "swimming"),
+            ]
 
     async def test_non_monday_raises(self) -> None:
         async with test_session() as session:

--- a/tests/test_scheduler/test_jobs.py
+++ b/tests/test_scheduler/test_jobs.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from mycoach.coaching.exceptions import PipelineSkip
+from mycoach.coaching.exceptions import NoAvailabilityConfigured, PipelineSkip
 from mycoach.scheduler.jobs import (
     _daily_briefing,
     _garmin_sync,
@@ -226,6 +226,100 @@ async def test_weekly_plan_raises_skip_on_duplicate(
         mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
         with pytest.raises(PipelineSkip):
             await _weekly_plan()
+
+
+async def test_weekly_plan_sends_no_availability_email_on_no_availability_configured(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """NoAvailabilityConfigured triggers the no-availability email, then still propagates."""
+    mock_engine.generate_weekly_plan = AsyncMock(
+        side_effect=NoAvailabilityConfigured("No availability configured for week of 2025-01-20")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.date") as mock_date,
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_no_availability", return_value=True) as mock_send,
+    ):
+        mock_date.today.return_value = date(2025, 1, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        with pytest.raises(NoAvailabilityConfigured):
+            await _weekly_plan()
+
+    mock_send.assert_called_once()
+    assert mock_send.call_args.kwargs["week_start"] == "2025-01-20"
+
+
+async def test_weekly_plan_no_availability_email_respects_preference(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """The no-availability email is not sent when the user has the preference off."""
+    mock_engine.generate_weekly_plan = AsyncMock(
+        side_effect=NoAvailabilityConfigured("No availability configured for week of 2025-01-20")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.date") as mock_date,
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        patch("mycoach.scheduler.jobs.send_no_availability", return_value=True) as mock_send,
+    ):
+        mock_date.today.return_value = date(2025, 1, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        with pytest.raises(NoAvailabilityConfigured):
+            await _weekly_plan()
+
+    mock_send.assert_not_called()
+
+
+async def test_weekly_plan_duplicate_skip_does_not_send_no_availability_email(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """A plain duplicate-plan PipelineSkip must not trigger the no-availability email."""
+    mock_engine.generate_weekly_plan = AsyncMock(
+        side_effect=PipelineSkip("Active plan already exists")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.date") as mock_date,
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch("mycoach.scheduler.jobs.send_no_availability", return_value=True) as mock_send,
+    ):
+        mock_date.today.return_value = date(2025, 1, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        with pytest.raises(PipelineSkip):
+            await _weekly_plan()
+
+    mock_send.assert_not_called()
+
+
+def test_weekly_plan_job_logs_skip_for_no_availability_configured(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The run is still recorded as skipped when NoAvailabilityConfigured is raised."""
+    mock_engine.generate_weekly_plan = AsyncMock(
+        side_effect=NoAvailabilityConfigured("No availability configured for week of 2025-01-20")
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.date") as mock_date,
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        caplog.at_level(logging.INFO),
+    ):
+        mock_date.today.return_value = date(2025, 1, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        job_weekly_plan()  # must not raise
+
+    skip_logs = [r for r in caplog.records if "weekly_plan skipped" in r.message]
+    assert skip_logs and all(r.levelno == logging.INFO for r in skip_logs)
+    assert not any(r.levelno >= logging.ERROR for r in caplog.records)
 
 
 def test_weekly_plan_job_logs_skip(


### PR DESCRIPTION
## Summary

Closes #25 — availability becomes a standing schedule with per-week overrides, so the weekly plan job no longer goes silent when a week isn't declared.

- New `default_availability` table (migration seeds it from the most recently declared week in `weekly_availabilities`), plus a nullable `availability_source` column on `weekly_plans`.
- `CoachingEngine.generate_weekly_plan` materializes the default into `weekly_availabilities` for an empty week, immediately before the existing availability fetch — the single seam every plan-generation path passes through. Raises the new `NoAvailabilityConfigured(PipelineSkip)` subclass when both the week and the default are empty.
- The scheduler catches `NoAvailabilityConfigured` and sends a "no plan generated" email (respecting the user's preference) before re-raising, so the run is still recorded as skipped as before. The duplicate-plan skip is unaffected.
- The weekly-plan email shows a "planned from your standing schedule" line when `availability_source` is `default`; a new `send_no_availability` email links straight to the default-schedule tab.
- New `GET/POST /api/availability/default` endpoint (separate from the per-week POST). The availability page gains a `week=default` tab and pre-fills the upcoming week from the default when nothing's been declared — display-only, writes nothing until saved.

## Test plan

- [x] `pytest` — full suite green except 10 tests in `tests/test_scheduler` that only fail under full-suite ordering due to a pre-existing caplog-isolation issue on `main` (confirmed present before this change); all pass in isolation.
- [x] New tests: engine materialization (`tests/test_plans/test_engine.py`), scheduler dispatch (`tests/test_scheduler/test_jobs.py`), email rendering (`tests/test_email/test_sender.py`), API + page behavior (`tests/test_api/test_availability.py`, `tests/test_pages/test_availability.py`), and the migration seed/downgrade (`tests/test_migrations/`).
- [x] `mypy` and `ruff` clean on all touched source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)