### PR TITLE
fix(scheduler): persist skip reason on job_runs

### DIFF
--- a/alembic/versions/c7d8e9f0a1b2_add_skip_reason_to_job_runs.py
+++ b/alembic/versions/c7d8e9f0a1b2_add_skip_reason_to_job_runs.py
@@ -1,0 +1,33 @@
+"""add skip_reason to job_runs
+
+Revision ID: c7d8e9f0a1b2
+Revises: b3c4d5e6f7a8
+Create Date: 2026-08-06 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7d8e9f0a1b2'
+down_revision: Union[str, Sequence[str], None] = 'b3c4d5e6f7a8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Nullable and left unbackfilled — existing rows genuinely have no recorded
+    # skip reason, and the `error` column keeps carrying failure detail as before.
+    op.add_column(
+        'job_runs',
+        sa.Column('skip_reason', sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('job_runs', 'skip_reason')

--- a/src/mycoach/models/job_run.py
+++ b/src/mycoach/models/job_run.py
@@ -22,6 +22,9 @@ class JobRun(Base):
     duration_ms: Mapped[int]
     status: Mapped[str] = mapped_column(String(20))  # success, skipped, failed
     error: Mapped[str | None] = mapped_column(Text, default=None)
+    # Populated only when status is "skipped" — a skip is not an error, so it
+    # gets its own column rather than overloading `error`.
+    skip_reason: Mapped[str | None] = mapped_column(Text, default=None)
     # Whether an email actually went out, kept deliberately separate from status
     # rather than folded into it. A run whose insight generated fine but whose
     # recipient has that email type switched off is a genuine success that sent

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -115,10 +115,11 @@ async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-d
 
     Writes one append-only ``JobRun`` row — job identifier, start time,
     duration, status (``success`` / ``skipped`` / ``failed``), error detail on
-    failure, and whether an email was delivered — and emits a structured log
-    line carrying the same facts. A ``PipelineSkip`` is a deliberate no-op
-    (``skipped``); every other exception is a real failure (``failed``).
-    Exceptions never propagate out to the scheduler.
+    failure, skip reason on skip, and whether an email was delivered — and
+    emits a structured log line carrying the same facts except the skip
+    reason, which the log line already carries inline. A ``PipelineSkip`` is a
+    deliberate no-op (``skipped``); every other exception is a real failure
+    (``failed``). Exceptions never propagate out to the scheduler.
 
     Delivery is read off the run's ``_Delivery`` tally rather than the body's
     return value, so it is recorded however the body exited — including a batch
@@ -145,8 +146,9 @@ async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-d
     duration_ms = int((time.perf_counter() - start) * 1000)
 
     # The row's error column is failure detail only, per the spec; a skip's
-    # reason is not an error and lives only in the log line below.
+    # reason is persisted separately in skip_reason instead.
     error = detail if status == "failed" else None
+    skip_reason = detail if status == "skipped" else None
 
     async with async_session() as session:
         session.add(
@@ -156,6 +158,7 @@ async def _record_run(job_name: str, coro) -> None:  # type: ignore[no-untyped-d
                 duration_ms=duration_ms,
                 status=status,
                 error=error,
+                skip_reason=skip_reason,
                 email_delivered=delivery.delivered,
             )
         )

--- a/tests/test_scheduler/test_job_runs.py
+++ b/tests/test_scheduler/test_job_runs.py
@@ -48,6 +48,7 @@ async def test_records_success() -> None:
     assert run.job_name == "daily_briefing"
     assert run.status == "success"
     assert run.error is None
+    assert run.skip_reason is None
     assert run.duration_ms >= 0
     assert run.started_at is not None
 
@@ -65,8 +66,9 @@ async def test_records_skip() -> None:
     assert len(runs) == 1
     assert runs[0].status == "skipped"
     # A skip is not an error, so no detail is persisted in the error column;
-    # the skip reason lives only in the structured log line.
+    # it lives in skip_reason instead.
     assert runs[0].error is None
+    assert runs[0].skip_reason == "Daily briefing already exists"
 
 
 async def test_records_failure_with_error_detail() -> None:
@@ -82,6 +84,7 @@ async def test_records_failure_with_error_detail() -> None:
     assert len(runs) == 1
     assert runs[0].status == "failed"
     assert runs[0].error == "LLM call blew up"
+    assert runs[0].skip_reason is None
 
 
 async def test_failure_is_not_re_raised() -> None:
@@ -257,6 +260,7 @@ async def test_weekly_plan_body_records_skip() -> None:
     assert len(runs) == 1
     assert runs[0].status == "skipped"
     assert runs[0].error is None
+    assert runs[0].skip_reason == "Active plan already exists"
 
 
 async def test_weekly_plan_body_records_failure() -> None:
@@ -379,6 +383,7 @@ async def test_post_workout_body_records_skip_when_nothing_to_analyse() -> None:
     runs = await _job_runs()
     assert len(runs) == 1
     assert runs[0].status == "skipped"
+    assert runs[0].skip_reason == "no new activities to analyse"
     mock_engine.generate_post_workout_analysis.assert_not_awaited()
 
 


### PR DESCRIPTION
Skips were only explained in the log line, which had long since rotated by the time anyone went looking. Add a nullable skip_reason column, populated from the same detail the recorder already computes, kept separate from error since a skip is not a failure.

Closes #27