### PR TITLE
fix(dashboard): make Synced HH:MM correct and responsive to Sync presses

### DIFF
--- a/alembic/versions/d1e2f3a4b5c6_add_updated_at_to_daily_health_snapshots.py
+++ b/alembic/versions/d1e2f3a4b5c6_add_updated_at_to_daily_health_snapshots.py
@@ -1,0 +1,33 @@
+"""add updated_at to daily_health_snapshots
+
+Revision ID: d1e2f3a4b5c6
+Revises: c7d8e9f0a1b2
+Create Date: 2026-08-06 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd1e2f3a4b5c6'
+down_revision: Union[str, Sequence[str], None] = 'c7d8e9f0a1b2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Nullable and left unbackfilled — existing rows have no recorded update time,
+    # and callers fall back to created_at when this is null.
+    op.add_column(
+        'daily_health_snapshots',
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('daily_health_snapshots', 'updated_at')

--- a/src/mycoach/api/pages/dashboard.py
+++ b/src/mycoach/api/pages/dashboard.py
@@ -129,9 +129,13 @@ async def dashboard(
             except (json.JSONDecodeError, TypeError):
                 today_session_details = None
 
-    # Last Garmin sync time
+    # Last Garmin sync time. updated_at is bumped on every successful sync touch
+    # (even ones that change nothing), so it's a truer "last synced" stamp than
+    # created_at, which is only ever set once per row.
     garmin_last_sync = await session.scalar(
-        select(func.max(DailyHealthSnapshot.created_at)).where(
+        select(
+            func.max(func.coalesce(DailyHealthSnapshot.updated_at, DailyHealthSnapshot.created_at))
+        ).where(
             DailyHealthSnapshot.user_id == USER_ID,
             DailyHealthSnapshot.data_source == "garmin",
         )

--- a/src/mycoach/api/routes/sources.py
+++ b/src/mycoach/api/routes/sources.py
@@ -204,7 +204,9 @@ async def get_sources_status(
 
     # Garmin status: check health snapshots and activities from garmin
     garmin_latest_health = await session.scalar(
-        select(func.max(DailyHealthSnapshot.created_at)).where(
+        select(
+            func.max(func.coalesce(DailyHealthSnapshot.updated_at, DailyHealthSnapshot.created_at))
+        ).where(
             DailyHealthSnapshot.user_id == DEFAULT_USER_ID,
             DailyHealthSnapshot.data_source == "garmin",
         )

--- a/src/mycoach/models/health.py
+++ b/src/mycoach/models/health.py
@@ -66,3 +66,6 @@ class DailyHealthSnapshot(Base):
 
     data_source: Mapped[str] = mapped_column(String(50), default="garmin")
     created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    # Bumped on every sync touch, including ones that leave every field unchanged —
+    # this is what "last synced" is measured from, not created_at.
+    updated_at: Mapped[datetime | None] = mapped_column(default=None)

--- a/src/mycoach/sources/garmin/mappers.py
+++ b/src/mycoach/sources/garmin/mappers.py
@@ -391,6 +391,9 @@ async def import_health_snapshot(session: AsyncSession, snapshot: DailyHealthSna
         new_val = getattr(snapshot, field)
         if new_val is not None:
             setattr(existing, field, new_val)
+    # Touched by a successful sync regardless of whether any field above actually
+    # changed — this is what the dashboard's "last synced" stamp reads from.
+    existing.updated_at = datetime.utcnow()
     logger.debug("Updated snapshot for %s with fresh data", snapshot.snapshot_date)
     return False
 

--- a/src/mycoach/templates/dashboard.html
+++ b/src/mycoach/templates/dashboard.html
@@ -11,7 +11,9 @@
         </div>
         <div class="flex items-center gap-4">
             {% if garmin_last_sync %}
-            <span class="text-xs font-mono text-zinc-600 hidden sm:inline">Synced {{ garmin_last_sync.strftime('%H:%M') }}</span>
+            <span class="text-xs font-mono text-zinc-600 hidden sm:inline">Synced {{ (garmin_last_sync|localtime).strftime('%H:%M') }}</span>
+            {% else %}
+            <span class="text-xs font-mono text-zinc-600 hidden sm:inline">Never synced</span>
             {% endif %}
             <button id="sync-btn" hx-post="/api/sources/sync/garmin?days=2" hx-swap="none"
                 class="font-semibold text-xs text-zinc-400 hover:text-accent-soft transition-colors disabled:opacity-50 disabled:cursor-not-allowed">

--- a/tests/test_pages/test_dashboard.py
+++ b/tests/test_pages/test_dashboard.py
@@ -1,11 +1,13 @@
 """Tests for the dashboard page route."""
 
 import json
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 from httpx import AsyncClient
 
+from mycoach.config import get_settings
 from mycoach.models.coaching import CoachingInsight
 from mycoach.models.health import DailyHealthSnapshot
 from mycoach.models.plan import PlannedSession, WeeklyPlan
@@ -280,3 +282,78 @@ async def test_dashboard_static_files(client: AsyncClient) -> None:
     icon_512_resp = await client.get("/static/icon-512.png")
     assert icon_512_resp.status_code == 200
     assert icon_512_resp.headers["content-type"] == "image/png"
+
+
+async def test_dashboard_never_synced_state(client: AsyncClient) -> None:
+    """With no Garmin data at all, the header shows a sensible never-synced state."""
+    await _seed_user()
+
+    resp = await client.get("/")
+    assert resp.status_code == 200
+    assert "Never synced" in resp.text
+    assert "Synced " not in resp.text  # no "Synced HH:MM" stamp rendered
+
+
+async def test_dashboard_shows_sync_time_in_local_timezone(client: AsyncClient) -> None:
+    """The 'Synced HH:MM' stamp renders in local time, not raw UTC."""
+    await _seed_user()
+    # Pick a UTC hour whose local rendering differs from the raw UTC hour,
+    # so the assertion actually exercises the timezone conversion.
+    utc_sync_time = datetime(2026, 6, 15, 23, 30, 0)
+    local_tz = ZoneInfo(get_settings().timezone)
+    expected_local = utc_sync_time.replace(tzinfo=ZoneInfo("UTC")).astimezone(local_tz)
+    assert expected_local.strftime("%H:%M") != utc_sync_time.strftime("%H:%M")
+
+    async with test_session() as session:
+        snapshot = DailyHealthSnapshot(
+            user_id=1,
+            snapshot_date=date.today(),
+            resting_hr=52,
+            data_source="garmin",
+        )
+        snapshot.created_at = utc_sync_time
+        session.add(snapshot)
+        await session.commit()
+
+    resp = await client.get("/")
+    assert resp.status_code == 200
+    assert f"Synced {expected_local.strftime('%H:%M')}" in resp.text
+    assert f"Synced {utc_sync_time.strftime('%H:%M')}" not in resp.text
+
+
+async def test_dashboard_sync_stamp_advances_on_no_op_resync(client: AsyncClient) -> None:
+    """Re-syncing identical data still moves the displayed stamp forward.
+
+    Mirrors what the dashboard's Sync button does against already-held data:
+    the row gets UPSERTed with no field changes, but updated_at must still
+    advance so the header time isn't stuck.
+    """
+    await _seed_user()
+    today = date.today()
+
+    async with test_session() as session:
+        snapshot = DailyHealthSnapshot(
+            user_id=1,
+            snapshot_date=today,
+            resting_hr=52,
+            data_source="garmin",
+        )
+        snapshot.created_at = datetime(2026, 1, 1, 5, 0, 0)
+        session.add(snapshot)
+        await session.commit()
+
+    resp = await client.get("/")
+    first_sync_text = resp.text
+
+    async with test_session() as session:
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(DailyHealthSnapshot).where(DailyHealthSnapshot.user_id == 1)
+        )
+        row = result.scalar_one()
+        row.updated_at = datetime(2026, 6, 15, 9, 0, 0)  # simulate a re-sync touch
+        await session.commit()
+
+    resp = await client.get("/")
+    assert resp.text != first_sync_text

--- a/tests/test_sources/test_garmin.py
+++ b/tests/test_sources/test_garmin.py
@@ -397,6 +397,39 @@ class TestImportHealthSnapshot:
             assert len(rows) == 2
             assert {row.data_source for row in rows} == {"garmin", "hevy"}
 
+    async def test_updated_at_bumped_even_when_no_field_changes(
+        self, setup_db
+    ) -> None:  # type: ignore[no-untyped-def]
+        """updated_at advances on every successful touch, not just on real changes.
+
+        This is what the dashboard's "last synced" stamp relies on — a re-sync
+        that UPSERTs identical data must still move the stamp.
+        """
+        from tests.conftest import test_session
+
+        async with test_session() as session:
+            user = await _create_user(session)
+            s1 = map_health_snapshot(
+                user_id=user.id, snapshot_date=date(2024, 6, 10), stats=SAMPLE_STATS
+            )
+            await import_health_snapshot(session, s1)
+            await session.commit()
+
+            result = await session.execute(select(DailyHealthSnapshot))
+            row = result.scalar_one()
+            assert row.updated_at is None
+
+            s2 = map_health_snapshot(
+                user_id=user.id, snapshot_date=date(2024, 6, 10), stats=SAMPLE_STATS
+            )
+            created = await import_health_snapshot(session, s2)
+            await session.commit()
+
+            assert created is False
+            result = await session.execute(select(DailyHealthSnapshot))
+            row = result.scalar_one()
+            assert row.updated_at is not None
+
 
 class TestImportActivities:
     async def test_import_new_activities(self, setup_db) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary
- Renders the dashboard's "Synced HH:MM" header in local time via the existing `localtime` filter
- Adds `updated_at` to `DailyHealthSnapshot`, bumped unconditionally on every successful sync UPSERT (even no-op ones), so the stamp reflects the actual sync time rather than the row's original `created_at`
- Reads "last synced" as `coalesce(updated_at, created_at)` in both the dashboard and sources-status endpoints
- Shows "Never synced" when there's no Garmin data yet

Closes #29

## Test plan
- [x] `uv run pytest tests/test_pages/test_dashboard.py tests/test_sources/test_garmin.py` — 40/40 passing
- [x] `uv run mypy` on changed files — clean
- [x] Full suite run — 599 passing; 10 pre-existing `test_scheduler/*` failures confirmed unrelated (same failures reproduce on `main` before this change, isolation issue not caused by this diff)
- [x] Reviewed via `/code-review` (Standards + Spec axes) — no hard violations; noted this fix addresses the issue's fault #3 by making the sync stamp unconditional rather than widening the Sync button's request window, which satisfies all acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)