### PR TITLE
fix(availability): don't silently promote a default rest day to gym

### DIFF
--- a/src/mycoach/templates/availability.html
+++ b/src/mycoach/templates/availability.html
@@ -47,7 +47,7 @@
                     <input type="checkbox" name="day_{{ day.day_of_week }}_enabled"
                         class="day-toggle h-5 w-5 rounded border-white/20 text-accent focus:ring-accent"
                         data-day="{{ day.day_of_week }}"
-                        {% if day.slot %}checked{% endif %}>
+                        {% if day.slot and (week == 'default' or day.slot.sport) %}checked{% endif %}>
                     <div class="flex items-center gap-3 flex-1">
                         <div class="w-10 text-center">
                             <p class="text-[10px] uppercase font-semibold tracking-[0.1em] text-zinc-500">{{ day.day_name[:3] }}</p>
@@ -65,7 +65,7 @@
                 </label>
 
                 <!-- Slot inputs (shown when day is enabled) -->
-                <div id="slot-{{ day.day_of_week }}" class="mt-3 pl-11 {% if not day.slot %}hidden{% endif %}">
+                <div id="slot-{{ day.day_of_week }}" class="mt-3 pl-11 {% if not day.slot or (week != 'default' and not day.slot.sport) %}hidden{% endif %}">
                     <div>
                         <label class="block text-[11px] font-medium text-zinc-500 uppercase tracking-wide mb-1">Sport</label>
                         <select name="day_{{ day.day_of_week }}_sport"

--- a/tests/test_pages/test_availability.py
+++ b/tests/test_pages/test_availability.py
@@ -168,6 +168,31 @@ async def test_availability_page_next_week_prefills_from_default(client: AsyncCl
         assert result.scalars().first() is None
 
 
+async def test_availability_page_next_week_prefills_rest_day_as_unchecked(
+    client: AsyncClient,
+) -> None:
+    """A default rest day (explicit sport=None row) pre-fills as unchecked.
+
+    Rendering it checked would leave the sport dropdown with nothing selected,
+    which the browser defaults to "gym" — silently turning a declared rest day
+    into a training day the moment the pre-filled week gets saved.
+    """
+    await _seed_user()
+    async with test_session() as session:
+        session.add(DefaultAvailability(user_id=1, day_of_week=0, sport="gym"))
+        session.add(DefaultAvailability(user_id=1, day_of_week=1, sport=None))
+        await session.commit()
+
+    resp = await client.get("/availability?week=next")
+    assert resp.status_code == 200
+    html = resp.text
+    day1_cb = re.search(r'name="day_1_enabled"[^>]*', html)
+    assert day1_cb is not None
+    assert "checked" not in day1_cb.group(0)
+    # Still marked as coming from the default, even though it's unchecked.
+    assert "From default" in html
+
+
 async def test_availability_page_next_week_declared_not_marked_as_default(
     client: AsyncClient,
 ) -> None:


### PR DESCRIPTION
## Summary

Issue #34's three build items were investigated first:

- The next-week form pre-filling from the standing schedule
- The plan email's "planned from default" provenance line
- The scheduler's no-availability notification email

All three were already fully implemented and tested by `f9c09a9`, which landed nominally scoped to the parent issue #25 but actually covered #32/#33/#34's requirements together.

The one gap found: a standing-schedule rest day (an explicit `DefaultAvailability` row with `sport=None`) pre-filled into the next-week form as **checked** with no sport option selected. Browsers silently default an unselected `<select>` to its first option ("gym"), so saving a pre-filled week would silently turn a declared rest day into a gym day — exactly the kind of lying #34 exists to kill. Fixed so current/next week only render such a day as checked when it actually has an assigned sport; the default tab (which has its own explicit "No training" option) is unchanged.

## Test plan

- [x] Added a regression test (`test_availability_page_next_week_prefills_rest_day_as_unchecked`) covering a default rest day pre-filling as unchecked
- [x] `pytest tests/test_pages/test_availability.py` — 11 passed
- [x] Full suite: 600 passed, same 10 pre-existing test-isolation failures present on `main` before this change (verified via `git stash` + full run on base branch)
- [x] `mypy src/mycoach/api/pages/availability.py` — no issues

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)