### PR TITLE
fix(briefing): give the daily briefing fresh health data

### DIFF
--- a/docs/superpowers/plans/2026-08-16-daily-briefing-fresh-health-data.md
+++ b/docs/superpowers/plans/2026-08-16-daily-briefing-fresh-health-data.md
@@ -1,0 +1,905 @@
+# Daily Briefing Fresh Health Data Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the daily briefing see the night it is assessing, and make a
+dataless Garmin day loudly visible instead of silently fabricated.
+
+**Architecture:** Four independent changes to the Garmin sync path and the
+briefing job. (1) `has_data` becomes a check on the *mapped snapshot's content*
+rather than the *HTTP response's type*, so Garmin's all-null skeleton is
+correctly recognised as "no data". (2) `ImportResult` gains structured
+`empty_health_days` and per-day API failure reporting, so callers can act on
+emptiness programmatically instead of parsing error strings. (3) The scheduler's
+sync lookback widens from 2 to 7 days (configurable), so late uploads are
+recovered rather than falling off a cliff. (4) `_daily_briefing` syncs
+immediately before generating and raises `PipelineSkip` when today still has no
+usable data.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy 2.x async, APScheduler,
+pytest + pytest-asyncio (`asyncio_mode = "auto"` — async tests need no
+decorator), ruff (line-length 100), mypy (`disallow_untyped_defs = true`).
+
+**Spec:** `docs/superpowers/specs/2026-08-16-daily-briefing-stale-health-data.md`
+
+## Global Constraints
+
+- Python 3.11 target (`pyproject.toml` `target-version = "py311"`). Use
+  `X | None` unions, not `Optional[X]`.
+- Ruff line-length is **100**. Ruff lint selects `E,W,F,I,B,N,UP,SIM`.
+- Mypy runs with `disallow_untyped_defs = true` — **every** new function needs
+  full type annotations, including `-> None`.
+- Tests live under `tests/`, mirroring `src/mycoach/`. `asyncio_mode = "auto"`,
+  so `async def test_*` needs no `@pytest.mark.asyncio`.
+- Single-user MVP: `USER_ID = 1` in `scheduler/jobs.py`.
+- Run tests with `uv run pytest`. Lint with `uv run ruff check .`.
+- Do **not** change `import_health_snapshot`'s null-filling semantics
+  (`sources/garmin/mappers.py:390-393`) — it is correct and the recovery of
+  14/08 depended on it.
+- Never make an empty Garmin day silently pass as success. That silence is the
+  bug being fixed.
+
+---
+
+### Task 1: Content-based `has_data` detection
+
+Today `_fetch_health_for_day` decides "did we get data?" with
+`isinstance(response, dict)`. Garmin's empty-day skeleton is a valid dict full
+of nulls, so it scores `True` on every field. This task replaces the type check
+with a content check on the mapped snapshot, and fixes the log line that lied.
+
+**Files:**
+- Modify: `src/mycoach/sources/garmin/mappers.py` (add `snapshot_has_data` near `_UPDATABLE_FIELDS`, line ~354-364)
+- Modify: `src/mycoach/sources/garmin/source.py:104-154` (`_fetch_health_for_day`)
+- Test: `tests/test_sources/test_garmin.py`
+
+**Interfaces:**
+- Consumes: `_UPDATABLE_FIELDS` (existing, `mappers.py:354`), `DailyHealthSnapshot` model.
+- Produces: `snapshot_has_data(snapshot: DailyHealthSnapshot) -> bool` — exported from `mycoach.sources.garmin.mappers`. Task 2 relies on `_fetch_health_for_day` already returning a content-based `has_data`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_sources/test_garmin.py`, at the end of the file:
+
+```python
+class TestSnapshotHasData:
+    def test_all_null_skeleton_has_no_data(self) -> None:
+        """Garmin's empty-day response is a valid dict of nulls — not data."""
+        skeleton = {
+            "restingHeartRate": None,
+            "maxHeartRate": None,
+            "totalSteps": None,
+            "calendarDate": "2026-08-14",
+        }
+        snapshot = map_health_snapshot(
+            user_id=1,
+            snapshot_date=date(2026, 8, 14),
+            stats=skeleton,
+            sleep={"dailySleepDTO": {}},
+            hrv={"hrvSummary": {}},
+        )
+        assert snapshot_has_data(snapshot) is False
+
+    def test_populated_snapshot_has_data(self) -> None:
+        snapshot = map_health_snapshot(
+            user_id=1,
+            snapshot_date=date(2026, 8, 13),
+            stats=SAMPLE_STATS,
+            sleep=SAMPLE_SLEEP,
+        )
+        assert snapshot_has_data(snapshot) is True
+
+    def test_raw_data_alone_is_not_data(self) -> None:
+        """raw_data is always set, so it must not count as content."""
+        snapshot = map_health_snapshot(
+            user_id=1,
+            snapshot_date=date(2026, 8, 14),
+            stats={"calendarDate": "2026-08-14"},
+        )
+        assert snapshot.raw_data is not None
+        assert snapshot_has_data(snapshot) is False
+```
+
+Add `snapshot_has_data` to the existing import block at the top of the file:
+
+```python
+from mycoach.sources.garmin.mappers import (
+    import_activities,
+    import_health_snapshot,
+    map_activity,
+    map_health_snapshot,
+    snapshot_has_data,
+)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_sources/test_garmin.py::TestSnapshotHasData -v`
+Expected: FAIL at collection with `ImportError: cannot import name 'snapshot_has_data'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/mycoach/sources/garmin/mappers.py`, directly after the
+`_UPDATABLE_FIELDS` list (ends line ~364), add:
+
+```python
+# raw_data is excluded: it is always written, even for Garmin's empty-day
+# skeleton, so its presence says nothing about whether the day has content.
+_CONTENT_FIELDS = [f for f in _UPDATABLE_FIELDS if f != "raw_data"]
+
+
+def snapshot_has_data(snapshot: DailyHealthSnapshot) -> bool:
+    """Does this snapshot carry any usable metric?
+
+    Garmin answers a day it has no data for with a well-formed JSON document
+    whose every metric is null. Checking the *response type* cannot tell that
+    apart from a rich day — checking the *mapped content* can.
+    """
+    return any(getattr(snapshot, field) is not None for field in _CONTENT_FIELDS)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_sources/test_garmin.py::TestSnapshotHasData -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Write the failing test for the source using it**
+
+Add to `tests/test_sources/test_garmin.py` inside `class TestGarminSource`:
+
+```python
+    async def test_null_skeleton_day_is_flagged_as_empty(self, setup_db) -> None:  # type: ignore[no-untyped-def]
+        """A dict-shaped but all-null Garmin response must count as no data."""
+        from tests.conftest import test_session
+
+        mock_client = MagicMock()
+        mock_client.get_stats.return_value = {"calendarDate": "2026-08-14"}
+        mock_client.get_sleep_data.return_value = {"dailySleepDTO": {}}
+        mock_client.get_hrv_data.return_value = {"hrvSummary": {}}
+        mock_client.get_stress_data.return_value = {}
+        mock_client.get_body_battery.return_value = []
+        mock_client.get_training_readiness.return_value = {}
+        mock_client.get_training_status.return_value = {}
+        mock_client.get_max_metrics.return_value = []
+        mock_client.get_respiration_data.return_value = {}
+        mock_client.get_spo2_data.return_value = {}
+        mock_client.get_activities_by_date.return_value = []
+
+        source = GarminSource(client=mock_client)
+
+        async with test_session() as session:
+            user = await _create_user(session)
+            await session.commit()
+
+            result = await source.fetch_and_import(
+                session, user.id, since=datetime(2026, 8, 14)
+            )
+
+            assert result.errors is not None
+            assert any("no usable Garmin health data" in e for e in result.errors)
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_sources/test_garmin.py::TestGarminSource::test_null_skeleton_day_is_flagged_as_empty -v`
+Expected: FAIL — `assert result.errors is not None` fails, because the current
+`isinstance` checks score the skeleton as data.
+
+- [ ] **Step 7: Replace the type check with the content check**
+
+In `src/mycoach/sources/garmin/source.py`, replace lines 121-154 (the
+`field_status` dict through the `return`) with:
+
+```python
+        snapshot = map_health_snapshot(
+            user_id=user_id,
+            snapshot_date=day,
+            stats=stats,
+            sleep=sleep,
+            hrv=hrv,
+            stress=stress,
+            body_battery=body_battery if isinstance(body_battery, list) else None,
+            training_readiness=training_readiness,
+            training_status=training_status,
+            max_metrics=max_metrics,
+            respiration=respiration,
+            spo2=spo2,
+        )
+
+        # Judge the mapped content, not the response type. Garmin answers a day
+        # it has nothing for with a well-formed document of nulls, which an
+        # isinstance() check scores as data — that is what hid two days of
+        # missing briefing data.
+        has_data = snapshot_has_data(snapshot)
+        if not has_data:
+            logger.warning(
+                "Garmin health fetch for %s: response carried no usable values", day
+            )
+        return snapshot, has_data
+```
+
+Update the import at the top of `source.py` — find the existing
+`from mycoach.sources.garmin.mappers import (...)` block and add
+`snapshot_has_data` to it (keep the names alphabetically sorted, ruff `I` will
+enforce this).
+
+- [ ] **Step 8: Run the full Garmin suite**
+
+Run: `uv run pytest tests/test_sources/test_garmin.py -v`
+Expected: PASS. `test_fetch_and_import` still passes (rich samples produce
+content) and `test_list_shaped_stats_for_today_does_not_crash` still passes
+(all-empty input still flags).
+
+- [ ] **Step 9: Lint**
+
+Run: `uv run ruff check src/mycoach/sources/garmin/ tests/test_sources/test_garmin.py`
+Expected: no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/mycoach/sources/garmin/mappers.py src/mycoach/sources/garmin/source.py tests/test_sources/test_garmin.py
+git commit -m "fix(garmin): judge day emptiness by snapshot content, not response type
+
+Garmin answers a day it has no data for with a well-formed JSON document
+whose every metric is null. The isinstance(x, dict) field_status check
+scored that as data, so empty days were logged identically to rich ones
+and never reached the empty_health_days warning."
+```
+
+---
+
+### Task 2: Report empty days and API failures as structured data
+
+`fetch_and_import` currently reports empty days only as a formatted string
+inside `errors`. Task 4 needs to ask "did *today* come back empty?" without
+parsing prose. This task also stops `_safe_call` from making a crashed endpoint
+look like an empty one.
+
+**Files:**
+- Modify: `src/mycoach/sources/base.py:9-21` (`ImportResult`)
+- Modify: `src/mycoach/sources/garmin/source.py:60-102` (`fetch_and_import`), `:104-154` (`_fetch_health_for_day`), `:156-162` (`_safe_call`)
+- Test: `tests/test_sources/test_garmin.py`
+
+**Interfaces:**
+- Consumes: `snapshot_has_data` from Task 1.
+- Produces:
+  - `ImportResult.empty_health_days: list[date]` (default `[]`) — days whose fetch produced no usable content.
+  - `GarminSource._safe_call(func, *args, failures: list[str] | None = None) -> Any` — appends `func.__name__` to `failures` on exception.
+  - `_fetch_health_for_day(user_id, day) -> tuple[DailyHealthSnapshot, bool, list[str]]` — third element is the names of Garmin calls that raised.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_sources/test_garmin.py` inside `class TestGarminSource`:
+
+```python
+    async def test_empty_days_exposed_as_structured_dates(self, setup_db) -> None:  # type: ignore[no-untyped-def]
+        """Callers must be able to ask 'was this day empty?' without parsing prose."""
+        from tests.conftest import test_session
+
+        mock_client = MagicMock()
+        mock_client.get_stats.return_value = {"calendarDate": "2026-08-14"}
+        mock_client.get_sleep_data.return_value = {}
+        mock_client.get_hrv_data.return_value = {}
+        mock_client.get_stress_data.return_value = {}
+        mock_client.get_body_battery.return_value = []
+        mock_client.get_training_readiness.return_value = {}
+        mock_client.get_training_status.return_value = {}
+        mock_client.get_max_metrics.return_value = []
+        mock_client.get_respiration_data.return_value = {}
+        mock_client.get_spo2_data.return_value = {}
+        mock_client.get_activities_by_date.return_value = []
+
+        source = GarminSource(client=mock_client)
+
+        async with test_session() as session:
+            user = await _create_user(session)
+            await session.commit()
+
+            result = await source.fetch_and_import(
+                session, user.id, since=datetime(2026, 8, 14)
+            )
+
+            assert date(2026, 8, 14) in result.empty_health_days
+
+    async def test_api_exception_reported_separately_from_emptiness(self, setup_db) -> None:  # type: ignore[no-untyped-def]
+        """A crashed endpoint must not masquerade as a day with no data."""
+        from tests.conftest import test_session
+
+        mock_client = MagicMock()
+        mock_client.get_stats.return_value = SAMPLE_STATS
+        mock_client.get_sleep_data.side_effect = RuntimeError("401 Unauthorized")
+        mock_client.get_hrv_data.return_value = SAMPLE_HRV
+        mock_client.get_stress_data.return_value = SAMPLE_STRESS
+        mock_client.get_body_battery.return_value = SAMPLE_BODY_BATTERY
+        mock_client.get_training_readiness.return_value = SAMPLE_TRAINING_READINESS
+        mock_client.get_training_status.return_value = SAMPLE_TRAINING_STATUS
+        mock_client.get_max_metrics.return_value = SAMPLE_MAX_METRICS
+        mock_client.get_respiration_data.return_value = SAMPLE_RESPIRATION
+        mock_client.get_spo2_data.return_value = SAMPLE_SPO2
+        mock_client.get_activities_by_date.return_value = []
+
+        source = GarminSource(client=mock_client)
+
+        async with test_session() as session:
+            user = await _create_user(session)
+            await session.commit()
+
+            result = await source.fetch_and_import(
+                session, user.id, since=datetime(2026, 8, 14)
+            )
+
+            assert result.errors is not None
+            assert any("get_sleep_data" in e for e in result.errors)
+            # The day still had other content, so it is not an "empty" day.
+            assert result.empty_health_days == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_sources/test_garmin.py::TestGarminSource::test_empty_days_exposed_as_structured_dates tests/test_sources/test_garmin.py::TestGarminSource::test_api_exception_reported_separately_from_emptiness -v`
+Expected: FAIL — first with `AttributeError: 'ImportResult' object has no attribute 'empty_health_days'`, second with the `get_sleep_data` assertion.
+
+- [ ] **Step 3: Add the field to `ImportResult`**
+
+In `src/mycoach/sources/base.py`, add to the dataclass (after
+`health_snapshots_updated`, before `errors`):
+
+```python
+    empty_health_days: list[date] = field(default_factory=list)
+```
+
+Update the imports at the top of `src/mycoach/sources/base.py`:
+
+```python
+from dataclasses import dataclass, field
+from datetime import date
+```
+
+(Keep the existing `from abc import ABC, abstractmethod` and any other imports;
+ruff `I` will order them.)
+
+- [ ] **Step 4: Make `_safe_call` record failures**
+
+In `src/mycoach/sources/garmin/source.py`, replace `_safe_call` (lines 156-162):
+
+```python
+    @staticmethod
+    def _safe_call(func: Any, *args: Any, failures: list[str] | None = None) -> Any:
+        """Call a Garmin API method, returning None on failure.
+
+        The failure is also appended to ``failures`` when one is given, because
+        a returned ``None`` alone cannot be told apart from an endpoint that
+        legitimately had nothing to report — and treating a crash as an empty
+        day is how a broken sync stays invisible.
+        """
+        try:
+            return func(*args)
+        except Exception as e:
+            logger.warning("Garmin API call %s failed: %s", func.__name__, e)
+            if failures is not None:
+                failures.append(func.__name__)
+            return None
+```
+
+- [ ] **Step 5: Thread failures through `_fetch_health_for_day`**
+
+In the same file, change the signature and the ten `_safe_call` lines
+(currently 104-119):
+
+```python
+    def _fetch_health_for_day(
+        self, user_id: int, day: date
+    ) -> tuple[DailyHealthSnapshot, bool, list[str]]:
+        """Fetch all health data for a single day and build a snapshot.
+
+        Each API call is wrapped individually so partial data is still captured.
+        Returns the snapshot, whether it carries usable content, and the names
+        of any Garmin calls that raised.
+        """
+        failures: list[str] = []
+        raw_stats = self._safe_call(self._client.get_stats, day, failures=failures)
+        stats = raw_stats if isinstance(raw_stats, dict) else {}
+        sleep = self._safe_call(self._client.get_sleep_data, day, failures=failures)
+        hrv = self._safe_call(self._client.get_hrv_data, day, failures=failures)
+        stress = self._safe_call(self._client.get_stress_data, day, failures=failures)
+        body_battery = self._safe_call(
+            self._client.get_body_battery, day, day, failures=failures
+        )
+        training_readiness = self._safe_call(
+            self._client.get_training_readiness, day, failures=failures
+        )
+        training_status = self._safe_call(
+            self._client.get_training_status, day, failures=failures
+        )
+        max_metrics = self._safe_call(self._client.get_max_metrics, day, failures=failures)
+        respiration = self._safe_call(
+            self._client.get_respiration_data, day, failures=failures
+        )
+        spo2 = self._safe_call(self._client.get_spo2_data, day, failures=failures)
+```
+
+and change the final `return` (written in Task 1 Step 7) to:
+
+```python
+        return snapshot, has_data, failures
+```
+
+- [ ] **Step 6: Update the caller loop**
+
+In `fetch_and_import`, replace lines 61-83 (the `empty_health_days` local
+through the `if empty_health_days:` block) with:
+
+```python
+        # Fetch health snapshots day by day
+        current = start_date
+        while current <= end_date:
+            try:
+                snapshot, has_data, failures = self._fetch_health_for_day(user_id, current)
+                if not has_data:
+                    result.empty_health_days.append(current)
+                if failures:
+                    errors.append(
+                        f"Garmin API calls failed for {current}: {', '.join(failures)}"
+                    )
+                created = await import_health_snapshot(session, snapshot)
+                if created:
+                    result.health_snapshots_created += 1
+                else:
+                    result.health_snapshots_updated += 1
+            except Exception as e:
+                await session.rollback()
+                errors.append(f"Health fetch failed for {current}: {e}")
+                logger.warning("Health fetch failed for %s: %s", current, e)
+            current += timedelta(days=1)
+
+        if result.empty_health_days:
+            errors.append(
+                f"{len(result.empty_health_days)} day(s) synced with no usable Garmin "
+                f"health data: {', '.join(str(d) for d in result.empty_health_days)}"
+            )
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_sources/test_garmin.py -v`
+Expected: PASS, all tests including the two new ones and the pre-existing
+`test_list_shaped_stats_for_today_does_not_crash`.
+
+- [ ] **Step 8: Run the wider suite for `ImportResult` consumers**
+
+Run: `uv run pytest tests/test_sources/ tests/test_api/ -v`
+Expected: PASS. `ImportResult` is also built in `sources/hevy/` and consumed by
+`api/routes/sources.py`; the new field has a default, so nothing else needs
+changing — this run proves it.
+
+- [ ] **Step 9: Lint and typecheck**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/mycoach/sources/`
+Expected: no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/mycoach/sources/base.py src/mycoach/sources/garmin/source.py tests/test_sources/test_garmin.py
+git commit -m "feat(garmin): expose empty days and API failures on ImportResult
+
+Empty days were reported only as a formatted string, so callers could not
+act on them. _safe_call also turned a crashed endpoint into an
+indistinguishable None, letting a broken sync look like a quiet day."
+```
+
+---
+
+### Task 3: Widen the scheduler's sync lookback to 7 days
+
+The scheduler looks back 2 days; the manual sync endpoint already defaults to 7.
+A Garmin upload that lands more than 2 days late is currently unrecoverable —
+which nearly lost 14/08 permanently.
+
+**Files:**
+- Modify: `src/mycoach/config.py` (add setting near `scheduler_sync_minute`, line ~70)
+- Modify: `src/mycoach/scheduler/jobs.py:200-225` (`job_garmin_sync`, `_garmin_sync`)
+- Test: `tests/test_scheduler/test_jobs.py`
+
+**Interfaces:**
+- Consumes: `get_settings()` (already imported in `scheduler/jobs.py:22`).
+- Produces:
+  - `Settings.scheduler_sync_lookback_days: int = 7`
+  - `_garmin_sync(days: int | None = None) -> ImportResult` — now **returns** the result, which Task 4 depends on. `days=None` reads the setting.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_scheduler/test_jobs.py`, after `test_garmin_sync_success`:
+
+```python
+async def test_garmin_sync_looks_back_seven_days_by_default(
+    mock_session: AsyncMock,
+) -> None:
+    """A late Garmin upload must still be recoverable days later."""
+    mock_source = MagicMock()
+    mock_source.authenticate = AsyncMock(return_value=True)
+    mock_result = MagicMock()
+    mock_result.health_snapshots_created = 0
+    mock_result.activities_created = 0
+    mock_source.fetch_and_import = AsyncMock(return_value=mock_result)
+    mock_merge = MagicMock(merged=0)
+
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.merge_garmin_hevy", AsyncMock(return_value=mock_merge)),
+    ):
+        await _garmin_sync()
+
+    since = mock_source.fetch_and_import.await_args.kwargs["since"]
+    assert (datetime.utcnow().date() - since.date()).days == 7
+
+
+async def test_garmin_sync_returns_the_import_result(mock_session: AsyncMock) -> None:
+    """The briefing job needs the result to decide whether to skip."""
+    mock_source = MagicMock()
+    mock_source.authenticate = AsyncMock(return_value=True)
+    mock_result = MagicMock()
+    mock_result.health_snapshots_created = 1
+    mock_result.activities_created = 0
+    mock_source.fetch_and_import = AsyncMock(return_value=mock_result)
+    mock_merge = MagicMock(merged=0)
+
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.merge_garmin_hevy", AsyncMock(return_value=mock_merge)),
+    ):
+        result = await _garmin_sync()
+
+    assert result is mock_result
+```
+
+Add `datetime` to the test file's imports — change line 4
+(`from datetime import date`) to:
+
+```python
+from datetime import date, datetime
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_scheduler/test_jobs.py::test_garmin_sync_looks_back_seven_days_by_default tests/test_scheduler/test_jobs.py::test_garmin_sync_returns_the_import_result -v`
+Expected: FAIL — the first asserts `2 == 7`, the second gets `None`.
+
+- [ ] **Step 3: Add the setting**
+
+In `src/mycoach/config.py`, after `scheduler_sync_minute: int = 0` (line ~70):
+
+```python
+    # Garmin uploads can land a day or more after the fact, so each sync
+    # re-fetches a window rather than only the newest days. import_health_snapshot
+    # fills nulls on re-fetch, so a wider window is pure recovery.
+    scheduler_sync_lookback_days: int = 7
+```
+
+- [ ] **Step 4: Use it, and return the result**
+
+In `src/mycoach/scheduler/jobs.py`, replace `job_garmin_sync` and
+`_garmin_sync` (lines 200-225) with:
+
+```python
+def job_garmin_sync() -> None:
+    """Sync health and activity data from Garmin Connect."""
+    logger.info("Scheduler: starting Garmin sync")
+    _run_recorded_job("garmin_sync", _garmin_sync())
+
+
+async def _garmin_sync(days: int | None = None) -> ImportResult:
+    """Fetch and import a window of Garmin data, returning what was imported.
+
+    The window is wider than "since the last run" on purpose: Garmin uploads
+    can arrive a day or more late, and ``import_health_snapshot`` fills nulls
+    on re-fetch, so re-asking for a day we already have can only improve it.
+    """
+    if days is None:
+        days = get_settings().scheduler_sync_lookback_days
+
+    source = GarminSource()
+    if not await source.authenticate():
+        raise RuntimeError("Garmin authentication failed")
+
+    async with async_session() as session:
+        since = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        since = since - timedelta(days=days)
+        result = await source.fetch_and_import(session, USER_ID, since=since)
+        merge_result = await merge_garmin_hevy(session, USER_ID)
+        await session.commit()
+        logger.info(
+            "Scheduler: Garmin sync complete — health=%d, activities=%d, merged=%d",
+            result.health_snapshots_created,
+            result.activities_created,
+            merge_result.merged,
+        )
+        return result
+```
+
+Add the import to `src/mycoach/scheduler/jobs.py` (near line 37, alongside the
+existing `from mycoach.sources.garmin.source import GarminSource`):
+
+```python
+from mycoach.sources.base import ImportResult
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_scheduler/test_jobs.py -v`
+Expected: PASS, including the pre-existing `test_garmin_sync_success` and
+`test_garmin_sync_auth_failure_raises`.
+
+- [ ] **Step 6: Confirm the setting is readable**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: PASS. The new field has a default, so no config test needs changing.
+
+- [ ] **Step 7: Lint**
+
+Run: `uv run ruff check src/mycoach/config.py src/mycoach/scheduler/jobs.py tests/test_scheduler/test_jobs.py`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/mycoach/config.py src/mycoach/scheduler/jobs.py tests/test_scheduler/test_jobs.py
+git commit -m "fix(scheduler): widen Garmin sync lookback from 2 to 7 days
+
+Garmin uploads can land more than 2 days late, at which point the old
+window had already closed and the day was unrecoverable. The manual sync
+endpoint already defaulted to 7."
+```
+
+---
+
+### Task 4: Briefing syncs first, and skips when there is nothing to brief on
+
+The briefing reads a snapshot written 3.5 hours earlier, before the night's
+sleep existed. This task makes it fetch its own data, and refuse to invent a
+recovery verdict when there genuinely is none.
+
+**Files:**
+- Modify: `src/mycoach/scheduler/jobs.py:228-242` (`job_daily_briefing`, `_daily_briefing`)
+- Test: `tests/test_scheduler/test_jobs.py`
+
+**Interfaces:**
+- Consumes: `_garmin_sync(days: int | None = None) -> ImportResult` (Task 3), `ImportResult.empty_health_days` (Task 2), `PipelineSkip` (already imported, `scheduler/jobs.py:21`).
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_scheduler/test_jobs.py`, after the existing
+`test_daily_briefing_success`:
+
+```python
+async def test_daily_briefing_syncs_before_generating(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """The briefing must fetch fresh data, not read a snapshot hours old."""
+    calls: list[str] = []
+
+    async def fake_sync(days: int | None = None) -> MagicMock:
+        calls.append("sync")
+        return MagicMock(empty_health_days=[])
+
+    async def fake_generate(*args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append("generate")
+        return MagicMock(content='{"readiness_verdict": "go_hard"}')
+
+    mock_engine.generate_daily_briefing = AsyncMock(side_effect=fake_generate)
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", fake_sync),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _daily_briefing()
+
+    assert calls == ["sync", "generate"]
+
+
+async def test_daily_briefing_skips_when_today_has_no_health_data(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """No data is a skip with a reason — never a briefing invented from nothing."""
+    today = date.today()
+
+    async def fake_sync(days: int | None = None) -> MagicMock:
+        return MagicMock(empty_health_days=[today])
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", fake_sync),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        pytest.raises(PipelineSkip, match="no usable health data"),
+    ):
+        await _daily_briefing()
+
+    mock_engine.generate_daily_briefing.assert_not_awaited()
+
+
+async def test_daily_briefing_proceeds_when_sync_fails(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """A sync failure must not block a briefing when the DB already has data."""
+
+    async def failing_sync(days: int | None = None) -> MagicMock:
+        raise RuntimeError("Garmin authentication failed")
+
+    mock_engine.generate_daily_briefing = AsyncMock(
+        return_value=MagicMock(content='{"readiness_verdict": "moderate"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", failing_sync),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _daily_briefing()
+
+    mock_engine.generate_daily_briefing.assert_awaited_once()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_scheduler/test_jobs.py -k daily_briefing -v`
+Expected: FAIL — `test_daily_briefing_syncs_before_generating` gets
+`calls == ["generate"]`, and the skip test gets no `PipelineSkip`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/mycoach/scheduler/jobs.py`, replace `_daily_briefing` (lines 234-242):
+
+```python
+async def _daily_briefing() -> None:
+    """Sync fresh Garmin data, then generate the briefing from it.
+
+    The sync is part of the job rather than a separate cron entry because the
+    coupling is real: a briefing about last night's sleep is meaningless
+    without last night's sleep, and the standalone 06:00 sync runs before
+    Garmin has finalised it. Encoding that in the job beats spacing two crons
+    and hoping.
+    """
+    today = date.today()
+
+    # A sync failure is not a reason to withhold a briefing — yesterday's data
+    # may well be enough, and the failure is logged either way. Only a
+    # confirmed absence of today's data below stops the run.
+    empty_days: list[date] = []
+    try:
+        sync_result = await _garmin_sync()
+        empty_days = list(sync_result.empty_health_days)
+    except Exception as e:  # noqa: BLE001 - logged, and the briefing may still be viable
+        logger.warning("Scheduler: pre-briefing Garmin sync failed — %s", e)
+
+    if today in empty_days:
+        raise PipelineSkip(
+            f"Garmin returned no usable health data for {today} — skipping the "
+            f"briefing rather than inferring recovery from nothing"
+        )
+
+    engine = CoachingEngine()
+    async with async_session() as session:
+        insight = await engine.generate_daily_briefing(session, USER_ID)
+        logger.info("Scheduler: daily briefing generated")
+
+        if await _get_user_email_pref("email_daily_briefing"):
+            content = json.loads(insight.content)
+            _deliver(partial(send_daily_briefing, content), "daily briefing")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_scheduler/test_jobs.py -k daily_briefing -v`
+Expected: PASS, including the pre-existing `test_daily_briefing_success`,
+`test_daily_briefing_raises_skip_on_duplicate`, `test_daily_briefing_job_logs_skip`
+and `test_daily_briefing_job_logs_malformed_response_as_failure`.
+
+> If `test_daily_briefing_success` now fails because it does not patch
+> `_garmin_sync`, patch it there too with
+> `patch("mycoach.scheduler.jobs._garmin_sync", AsyncMock(return_value=MagicMock(empty_health_days=[])))`.
+> Do not weaken the new behaviour to accommodate the old test.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest`
+Expected: PASS. Pay attention to `tests/test_scheduler/test_job_runs.py` and
+`tests/test_email/test_job_email.py`, which drive `_daily_briefing` end-to-end
+and may need the same `_garmin_sync` patch.
+
+- [ ] **Step 6: Lint and typecheck**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/mycoach/scheduler/`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mycoach/scheduler/jobs.py tests/test_scheduler/test_jobs.py
+git commit -m "fix(briefing): sync Garmin before generating, skip when no data
+
+The briefing ran 3.5h after the sync and read a snapshot written before
+Garmin had finalised the night's sleep, so it never saw the night it
+exists to assess. It now fetches its own data, and skips with a recorded
+reason rather than inferring a recovery verdict from nothing."
+```
+
+---
+
+### Task 5: Update the scheduler docstring and verify against production
+
+The module docstring still describes the old job layout, and the fix should be
+confirmed against the real Garmin account before it is trusted.
+
+**Files:**
+- Modify: `src/mycoach/scheduler/scheduler.py:1-11` (module docstring), `:59-60` (comment)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4. Produces: nothing.
+
+- [ ] **Step 1: Update the docstring**
+
+In `src/mycoach/scheduler/scheduler.py`, update the numbered list in the module
+docstring so entry 2 reads:
+
+```
+2. Daily briefing (default 9:30 AM) — syncs Garmin first, then generates the
+   briefing from the fresh data. The standalone 6:00 AM sync runs before Garmin
+   has finalised the night's sleep, so the briefing cannot rely on it.
+```
+
+And update the comment at line 59 from `# 2. Daily briefing — daily, after
+Garmin sync` to `# 2. Daily briefing — daily; syncs Garmin itself first`.
+
+- [ ] **Step 2: Run the full suite one final time**
+
+Run: `uv run pytest && uv run ruff check src/ tests/ && uv run mypy src/mycoach/`
+Expected: all PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mycoach/scheduler/scheduler.py
+git commit -m "docs(scheduler): describe the briefing's own Garmin sync"
+```
+
+- [ ] **Step 4: Verify against production**
+
+Deploy, then on the homelab (`ssh 192.168.1.142`) trigger a real briefing and
+confirm the prompt now carries today's sleep:
+
+```bash
+TOKEN=$(docker exec mycoach printenv MYCOACH_API_TOKEN)
+curl -s -X POST -H "X-API-Key: $TOKEN" localhost:8000/api/system/scheduler/trigger/daily_briefing
+sleep 60
+docker exec mycoach python -c "import sqlite3; c=sqlite3.connect('/data/mycoach.db'); print(*[r[0][:900] for r in c.execute(\"select prompt_text from prompt_logs where prompt_type='daily_briefing' order by id desc limit 1\")], sep='\n')"
+```
+
+Expected: the `## Today's Health Data` section lists `Sleep score`, `HRV`, and
+`Body Battery (morning)` — not `No health data available for today.`
+
+> A briefing already exists for today after a normal run, so this will raise
+> `PipelineSkip("Daily briefing already exists")`. To force a real regeneration,
+> delete today's insight first, or run the check on a day before 09:30.
+
+---
+
+## Notes for the implementer
+
+**Why the no-data guard is in the job, not the engine.** `generate_daily_briefing`
+is also called by the manual API route, and three existing engine tests
+(`test_logs_prompt`, `test_duplicate_raises`, `test_llm_failure_raises_and_logs`
+in `tests/test_coaching/test_engine.py`) deliberately run with no health rows.
+Putting the guard in the engine would break them and would block ad-hoc manual
+generation. The job is where "we just synced and Garmin gave nothing" is known.
+
+**Do not "fix" the empty row by not writing it.** Writing a row for a dataless
+day is correct — `import_health_snapshot` later fills its nulls, which is
+exactly how 14/08 and 15/08 were recovered. The bug was never the row; it was
+calling that row a success.

--- a/docs/superpowers/specs/2026-08-16-daily-briefing-stale-health-data.md
+++ b/docs/superpowers/specs/2026-08-16-daily-briefing-stale-health-data.md
@@ -1,0 +1,103 @@
+# Spec: Daily briefing reads stale/empty health data
+
+**Status:** Agreed 2026-08-16
+**Reported by:** Felipe (prompt logs for 13/08, 14/08, 15/08 briefings)
+
+## Symptom
+
+The `daily_briefing` prompt's `## Today's Health Data` section reads
+`No health data available for today.` (14/08, 15/08) or contains only a thin
+subset — resting HR, max HR, stress, SpO2, with no sleep, HRV, or Body Battery
+(13/08). The briefing's entire purpose is to assess last night's sleep and
+recovery, so it was producing verdicts from nothing.
+
+## Diagnosis (evidence-backed)
+
+Evidence gathered from the production container on the homelab
+(`docker exec mycoach`, SQLite at `/data/mycoach.db`) on 2026-08-15.
+
+### Root cause: the sync asks Garmin before Garmin has the answer
+
+`garmin_sync` fires at 06:00 Europe/London (05:00 UTC). At that hour the user is
+asleep and the watch has not pushed the night to Garmin Connect. Garmin answers
+with an *all-null skeleton* — a ~6 KB JSON document with `calendarDate` set and
+every metric `null`. That skeleton is mapped to an all-NULL snapshot row and
+written to the DB.
+
+The briefing then runs at 09:30 and reads that row. **Nothing re-syncs between
+06:00 and 09:30** (`scheduler/scheduler.py:48-66`), so the briefing is
+structurally incapable of seeing the night it exists to assess.
+
+Proof — the 13/08 row was partial in its own 08:30 briefing but is complete in
+the DB today (sleep score 80, HRV 73, Body Battery 92). The data existed; the
+briefing never saw it, because it only arrived with the *next* day's sync via
+`import_health_snapshot`'s null-filling (`sources/garmin/mappers.py:390-393`).
+
+### Compounding cause: a 2-day lookback that closes the window
+
+`_garmin_sync` (`scheduler/jobs.py:215-216`) fetches only `today-2 … today`.
+The 14/08 data uploaded to Garmin at some point during the 15th — 18+ hours
+after the 15/08 05:00 sync had already asked and been told "nothing". After
+2026-08-16's run, 14/08 would have fallen permanently outside the window despite
+`import_health_snapshot` being perfectly able to fill it.
+
+Confirmed by experiment: a manual sync at 23:50 on 15/08 turned both empty days
+into full ones.
+
+| Date | `raw_data` before | after | sleep/HRV/BB after |
+|---|---|---|---|
+| 14/08 | 6,290 B (null skeleton) | 268,857 B | populated |
+| 15/08 | 5,883 B (null skeleton) | 227,544 B | populated |
+
+Note that the manual sync endpoint (`api/routes/sources.py:134`) already
+defaults to **7** days — the scheduler's 2 is the outlier.
+
+### Why it went unnoticed for days
+
+Three independent silences:
+
+1. `_safe_call` (`sources/garmin/source.py:157-162`) swallows every exception
+   into `None`. A dead API and a dataless day produce identical rows.
+2. `field_status` (`sources/garmin/source.py:121-132`) is an
+   `isinstance(x, dict)` **type** check. The 6 KB all-null skeleton scored
+   `'sleep': True, 'hrv': True`. The logged flags were byte-identical on 10/08
+   (rich data) and 14/08 (empty) — the instrumentation actively misled the
+   investigation.
+3. `has_data = any(field_status.values())` therefore never fired, so
+   `empty_health_days` stayed empty, `job_runs.error` stayed blank, and every
+   run reported `success`. Two days of data loss produced zero signal.
+
+### Explicitly not a cause
+
+- Not Garmin auth — `garmin_sync` succeeded every day 12–15/08.
+- Not a dead scheduler — container up 8 days healthy, all 5 jobs registered.
+- Not a device/watch fault — the data was in Garmin Connect all along.
+- Not a timezone bug — cron `hour=6` Europe/London = 05:00 UTC, as observed.
+
+## Decisions
+
+| # | Decision | Chosen |
+|---|---|---|
+| Q4/Q9 | How the briefing gets fresh data | **Briefing syncs immediately before generating, AND the lookback widens to 7 days.** Both are needed: a pre-briefing sync alone would still have missed 14/08 (that upload landed later on the 15th); only the wider window recovers it. |
+| Q7 | Behaviour when the fresh sync genuinely returns nothing | **Skip the briefing**, recording `job_runs.status='skipped'` with a reason. Fabricated recovery advice from absent data is worse than no briefing. |
+| — | Where the no-data guard lives | **In the job (`_daily_briefing`), not the engine.** The decision is "we just synced and Garmin gave nothing", which is job-level knowledge. Keeps the manual API route usable for ad-hoc generation and avoids disturbing three existing engine tests that deliberately run without health rows. |
+
+## Requirements
+
+- R1. `_daily_briefing` runs a Garmin sync before calling the coaching engine.
+- R2. The scheduler's sync lookback is 7 days, configurable.
+- R3. `has_data` is decided by snapshot **content**, not response **type**.
+- R4. A day with no usable content is reported: `ImportResult` carries the empty
+      days as structured data, not only as a formatted error string.
+- R5. An exception from a Garmin call is distinguishable from an empty response,
+      and is surfaced in `ImportResult.errors`.
+- R6. When the post-sync snapshot for today has no usable content, the briefing
+      raises `PipelineSkip` with a reason naming the date.
+- R7. A sync failure inside the briefing job must not prevent a briefing when
+      usable data is already in the DB.
+
+## Out of scope (backlog)
+
+- User-facing staleness alert ("no Garmin data in N days"). Agreed valuable,
+  deferred.
+- Additional sync runs per day (e.g. an evening sync).

--- a/src/mycoach/config.py
+++ b/src/mycoach/config.py
@@ -68,6 +68,10 @@ class Settings(BaseSettings):
     scheduler_timezone: str = ""
     scheduler_sync_hour: int = 6
     scheduler_sync_minute: int = 0
+    # Garmin uploads can land a day or more after the fact, so each sync
+    # re-fetches a window rather than only the newest days. import_health_snapshot
+    # fills nulls on re-fetch, so a wider window is pure recovery.
+    scheduler_sync_lookback_days: int = 7
     scheduler_briefing_hour: int = 9
     scheduler_briefing_minute: int = 30
     scheduler_post_workout_hour: int = 7

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -17,6 +17,7 @@ from functools import partial
 
 from sqlalchemy import select
 
+from mycoach.coaching.context import get_today_health
 from mycoach.coaching.engine import CoachingEngine
 from mycoach.coaching.exceptions import NoAvailabilityConfigured, PipelineSkip
 from mycoach.config import get_settings
@@ -43,6 +44,20 @@ logger = logging.getLogger(__name__)
 USER_ID = 1  # Single-user MVP
 
 DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+
+# The fields that make a briefing about recovery rather than about nothing —
+# sleep, HRV, and Body Battery. A snapshot can pass the empty-day guard (it has
+# *some* content, e.g. resting HR and steps) while carrying none of these, which
+# is exactly the 13/08 symptom the spec opens with. Named here so the intent
+# behind the check below is legible, not a bare inline tuple.
+_RECOVERY_FIELDS = (
+    "sleep_duration_minutes",
+    "sleep_score",
+    "hrv_status",
+    "hrv_7day_avg",
+    "hrv_status_text",
+    "body_battery_morning",
+)
 
 
 def _run_async(coro):  # type: ignore[no-untyped-def]
@@ -257,8 +272,8 @@ async def _daily_briefing() -> None:
     try:
         sync_result = await _garmin_sync()
         empty_days = list(sync_result.empty_health_days)
-    except Exception as e:  # noqa: BLE001 - logged, and the briefing may still be viable
-        logger.warning("Scheduler: pre-briefing Garmin sync failed — %s", e)
+    except Exception as e:  # logged, and the briefing may still be viable
+        logger.error("Scheduler: pre-briefing Garmin sync failed — %s", e)
 
     if today in empty_days:
         raise PipelineSkip(
@@ -268,6 +283,17 @@ async def _daily_briefing() -> None:
 
     engine = CoachingEngine()
     async with async_session() as session:
+        # A day can carry some content (e.g. resting HR, steps) yet none of the
+        # fields the briefing exists to speak to. That is not "no data" — the
+        # skip above is deliberately narrow — but it must not pass silently.
+        today_health = await get_today_health(session, USER_ID, today)
+        if not any(field in today_health for field in _RECOVERY_FIELDS):
+            logger.warning(
+                "Scheduler: generating daily briefing for %s without any recovery "
+                "data (no sleep, HRV, or Body Battery)",
+                today,
+            )
+
         insight = await engine.generate_daily_briefing(session, USER_ID)
         logger.info("Scheduler: daily briefing generated")
 

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -240,6 +240,32 @@ def job_daily_briefing() -> None:
 
 
 async def _daily_briefing() -> None:
+    """Sync fresh Garmin data, then generate the briefing from it.
+
+    The sync is part of the job rather than a separate cron entry because the
+    coupling is real: a briefing about last night's sleep is meaningless
+    without last night's sleep, and the standalone 06:00 sync runs before
+    Garmin has finalised it. Encoding that in the job beats spacing two crons
+    and hoping.
+    """
+    today = date.today()
+
+    # A sync failure is not a reason to withhold a briefing — yesterday's data
+    # may well be enough, and the failure is logged either way. Only a
+    # confirmed absence of today's data below stops the run.
+    empty_days: list[date] = []
+    try:
+        sync_result = await _garmin_sync()
+        empty_days = list(sync_result.empty_health_days)
+    except Exception as e:  # noqa: BLE001 - logged, and the briefing may still be viable
+        logger.warning("Scheduler: pre-briefing Garmin sync failed — %s", e)
+
+    if today in empty_days:
+        raise PipelineSkip(
+            f"Garmin returned no usable health data for {today} — skipping the "
+            f"briefing rather than inferring recovery from nothing"
+        )
+
     engine = CoachingEngine()
     async with async_session() as session:
         insight = await engine.generate_daily_briefing(session, USER_ID)

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -34,6 +34,7 @@ from mycoach.models.coaching import CoachingInsight
 from mycoach.models.job_run import JobRun
 from mycoach.models.plan import PlannedSession
 from mycoach.models.user import User
+from mycoach.sources.base import ImportResult
 from mycoach.sources.garmin.source import GarminSource
 from mycoach.sources.merger import merge_garmin_hevy
 
@@ -198,22 +199,28 @@ async def _get_user_email_pref(pref_field: str) -> bool:
 
 
 def job_garmin_sync() -> None:
-    """Sync health and activity data from Garmin Connect.
-
-    Fetches the last 2 days of data to handle timezone edge cases and overnight sync.
-    """
+    """Sync health and activity data from Garmin Connect."""
     logger.info("Scheduler: starting Garmin sync")
     _run_recorded_job("garmin_sync", _garmin_sync())
 
 
-async def _garmin_sync() -> None:
+async def _garmin_sync(days: int | None = None) -> ImportResult:
+    """Fetch and import a window of Garmin data, returning what was imported.
+
+    The window is wider than "since the last run" on purpose: Garmin uploads
+    can arrive a day or more late, and ``import_health_snapshot`` fills nulls
+    on re-fetch, so re-asking for a day we already have can only improve it.
+    """
+    if days is None:
+        days = get_settings().scheduler_sync_lookback_days
+
     source = GarminSource()
     if not await source.authenticate():
         raise RuntimeError("Garmin authentication failed")
 
     async with async_session() as session:
         since = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
-        since = since - timedelta(days=2)
+        since = since - timedelta(days=days)
         result = await source.fetch_and_import(session, USER_ID, since=since)
         merge_result = await merge_garmin_hevy(session, USER_ID)
         await session.commit()
@@ -223,6 +230,7 @@ async def _garmin_sync() -> None:
             result.activities_created,
             merge_result.merged,
         )
+        return result
 
 
 def job_daily_briefing() -> None:

--- a/src/mycoach/scheduler/scheduler.py
+++ b/src/mycoach/scheduler/scheduler.py
@@ -2,7 +2,9 @@
 
 The scheduler runs five jobs as part of the daily coaching pipeline:
 1. Garmin sync (default 6:00 AM) — fetch health + activity data
-2. Daily briefing (default 6:30 AM) — LLM-generated coaching for the day
+2. Daily briefing (default 9:30 AM) — syncs Garmin first, then generates the
+   briefing from the fresh data. The standalone 6:00 AM sync runs before Garmin
+   has finalised the night's sleep, so the briefing cannot rely on it.
 3. Post-workout analysis (default 7:00 AM) — analyze new activities after sync
 4. Weekly plan (default Sunday 6:00 PM) — generate next week's training plan
 5. Weekly recap (default Monday 7:00 AM) — recap the previous week
@@ -56,7 +58,7 @@ def create_scheduler(settings: Settings) -> BackgroundScheduler:
         replace_existing=True,
     )
 
-    # 2. Daily briefing — daily, after Garmin sync
+    # 2. Daily briefing — daily; syncs Garmin itself first
     scheduler.add_job(
         job_daily_briefing,
         "cron",

--- a/src/mycoach/sources/base.py
+++ b/src/mycoach/sources/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from datetime import datetime
+from dataclasses import dataclass, field
+from datetime import date, datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,6 +14,7 @@ class ImportResult:
     activities_skipped: int = 0
     health_snapshots_created: int = 0
     health_snapshots_updated: int = 0
+    empty_health_days: list[date] = field(default_factory=list)
     errors: list[str] | None = None
 
     @property

--- a/src/mycoach/sources/garmin/mappers.py
+++ b/src/mycoach/sources/garmin/mappers.py
@@ -378,6 +378,17 @@ def snapshot_has_data(snapshot: DailyHealthSnapshot) -> bool:
     return any(getattr(snapshot, field) is not None for field in _CONTENT_FIELDS)
 
 
+def snapshot_null_content_fields(snapshot: DailyHealthSnapshot) -> list[str]:
+    """Names of the content fields that came back null on this snapshot.
+
+    Same source of truth as ``snapshot_has_data`` — the mapped snapshot, not
+    the raw response shape — so a caller can log which part of a *partial*
+    day was missing without resurrecting the old per-field ``isinstance``
+    checks that lied about emptiness.
+    """
+    return [field for field in _CONTENT_FIELDS if getattr(snapshot, field) is None]
+
+
 async def import_health_snapshot(session: AsyncSession, snapshot: DailyHealthSnapshot) -> bool:
     """Import a health snapshot, or update an existing one with newer data.
 

--- a/src/mycoach/sources/garmin/mappers.py
+++ b/src/mycoach/sources/garmin/mappers.py
@@ -363,6 +363,20 @@ _UPDATABLE_FIELDS = [
     "steps", "respiration_avg", "spo2_avg", "intensity_minutes", "raw_data",
 ]
 
+# raw_data is excluded: it is always written, even for Garmin's empty-day
+# skeleton, so its presence says nothing about whether the day has content.
+_CONTENT_FIELDS = [f for f in _UPDATABLE_FIELDS if f != "raw_data"]
+
+
+def snapshot_has_data(snapshot: DailyHealthSnapshot) -> bool:
+    """Does this snapshot carry any usable metric?
+
+    Garmin answers a day it has no data for with a well-formed JSON document
+    whose every metric is null. Checking the *response type* cannot tell that
+    apart from a rich day — checking the *mapped content* can.
+    """
+    return any(getattr(snapshot, field) is not None for field in _CONTENT_FIELDS)
+
 
 async def import_health_snapshot(session: AsyncSession, snapshot: DailyHealthSnapshot) -> bool:
     """Import a health snapshot, or update an existing one with newer data.

--- a/src/mycoach/sources/garmin/source.py
+++ b/src/mycoach/sources/garmin/source.py
@@ -15,6 +15,7 @@ from mycoach.sources.garmin.mappers import (
     import_activities,
     import_health_snapshot,
     map_health_snapshot,
+    snapshot_has_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -118,25 +119,6 @@ class GarminSource(DataSource):
         respiration = self._safe_call(self._client.get_respiration_data, day)
         spo2 = self._safe_call(self._client.get_spo2_data, day)
 
-        field_status = {
-            "stats": bool(stats),
-            "sleep": isinstance(sleep, dict),
-            "hrv": isinstance(hrv, dict),
-            "stress": isinstance(stress, dict),
-            "body_battery": isinstance(body_battery, list),
-            "training_readiness": isinstance(training_readiness, dict),
-            "training_status": isinstance(training_status, dict),
-            "max_metrics": bool(max_metrics),
-            "respiration": isinstance(respiration, dict),
-            "spo2": isinstance(spo2, dict),
-        }
-        if not any(field_status.values()):
-            logger.warning(
-                "Garmin health fetch for %s: no usable fields at all — %s", day, field_status
-            )
-        elif not all(field_status.values()):
-            logger.info("Garmin health fetch for %s: partial data — %s", day, field_status)
-
         snapshot = map_health_snapshot(
             user_id=user_id,
             snapshot_date=day,
@@ -151,7 +133,17 @@ class GarminSource(DataSource):
             respiration=respiration,
             spo2=spo2,
         )
-        return snapshot, any(field_status.values())
+
+        # Judge the mapped content, not the response type. Garmin answers a day
+        # it has nothing for with a well-formed document of nulls, which an
+        # isinstance() check scores as data — that is what hid two days of
+        # missing briefing data.
+        has_data = snapshot_has_data(snapshot)
+        if not has_data:
+            logger.warning(
+                "Garmin health fetch for %s: response carried no usable values", day
+            )
+        return snapshot, has_data
 
     @staticmethod
     def _safe_call(func: Any, *args: Any) -> Any:

--- a/src/mycoach/sources/garmin/source.py
+++ b/src/mycoach/sources/garmin/source.py
@@ -59,13 +59,16 @@ class GarminSource(DataSource):
             start_date = end_date - timedelta(days=7)
 
         # Fetch health snapshots day by day
-        empty_health_days: list[date] = []
         current = start_date
         while current <= end_date:
             try:
-                snapshot, has_data = self._fetch_health_for_day(user_id, current)
+                snapshot, has_data, failures = self._fetch_health_for_day(user_id, current)
                 if not has_data:
-                    empty_health_days.append(current)
+                    result.empty_health_days.append(current)
+                if failures:
+                    errors.append(
+                        f"Garmin API calls failed for {current}: {', '.join(failures)}"
+                    )
                 created = await import_health_snapshot(session, snapshot)
                 if created:
                     result.health_snapshots_created += 1
@@ -77,10 +80,10 @@ class GarminSource(DataSource):
                 logger.warning("Health fetch failed for %s: %s", current, e)
             current += timedelta(days=1)
 
-        if empty_health_days:
+        if result.empty_health_days:
             errors.append(
-                f"{len(empty_health_days)} day(s) synced with no usable Garmin health data: "
-                f"{', '.join(str(d) for d in empty_health_days)}"
+                f"{len(result.empty_health_days)} day(s) synced with no usable Garmin "
+                f"health data: {', '.join(str(d) for d in result.empty_health_days)}"
             )
 
         # Fetch activities for the date range
@@ -102,22 +105,35 @@ class GarminSource(DataSource):
             result.errors = errors
         return result
 
-    def _fetch_health_for_day(self, user_id: int, day: date) -> tuple[DailyHealthSnapshot, bool]:
+    def _fetch_health_for_day(
+        self, user_id: int, day: date
+    ) -> tuple[DailyHealthSnapshot, bool, list[str]]:
         """Fetch all health data for a single day and build a snapshot.
 
         Each API call is wrapped individually so partial data is still captured.
+        Returns the snapshot, whether it carries usable content, and the names
+        of any Garmin calls that raised.
         """
-        raw_stats = self._safe_call(self._client.get_stats, day)
+        failures: list[str] = []
+        raw_stats = self._safe_call(self._client.get_stats, day, failures=failures)
         stats = raw_stats if isinstance(raw_stats, dict) else {}
-        sleep = self._safe_call(self._client.get_sleep_data, day)
-        hrv = self._safe_call(self._client.get_hrv_data, day)
-        stress = self._safe_call(self._client.get_stress_data, day)
-        body_battery = self._safe_call(self._client.get_body_battery, day, day)
-        training_readiness = self._safe_call(self._client.get_training_readiness, day)
-        training_status = self._safe_call(self._client.get_training_status, day)
-        max_metrics = self._safe_call(self._client.get_max_metrics, day)
-        respiration = self._safe_call(self._client.get_respiration_data, day)
-        spo2 = self._safe_call(self._client.get_spo2_data, day)
+        sleep = self._safe_call(self._client.get_sleep_data, day, failures=failures)
+        hrv = self._safe_call(self._client.get_hrv_data, day, failures=failures)
+        stress = self._safe_call(self._client.get_stress_data, day, failures=failures)
+        body_battery = self._safe_call(
+            self._client.get_body_battery, day, day, failures=failures
+        )
+        training_readiness = self._safe_call(
+            self._client.get_training_readiness, day, failures=failures
+        )
+        training_status = self._safe_call(
+            self._client.get_training_status, day, failures=failures
+        )
+        max_metrics = self._safe_call(self._client.get_max_metrics, day, failures=failures)
+        respiration = self._safe_call(
+            self._client.get_respiration_data, day, failures=failures
+        )
+        spo2 = self._safe_call(self._client.get_spo2_data, day, failures=failures)
 
         snapshot = map_health_snapshot(
             user_id=user_id,
@@ -143,13 +159,25 @@ class GarminSource(DataSource):
             logger.warning(
                 "Garmin health fetch for %s: response carried no usable values", day
             )
-        return snapshot, has_data
+        return snapshot, has_data, failures
 
     @staticmethod
-    def _safe_call(func: Any, *args: Any) -> Any:
-        """Call a Garmin API method, returning None on failure."""
+    def _safe_call(func: Any, *args: Any, failures: list[str] | None = None) -> Any:
+        """Call a Garmin API method, returning None on failure.
+
+        The failure is also appended to ``failures`` when one is given, because
+        a returned ``None`` alone cannot be told apart from an endpoint that
+        legitimately had nothing to report — and treating a crash as an empty
+        day is how a broken sync stays invisible.
+        """
         try:
             return func(*args)
         except Exception as e:
-            logger.warning("Garmin API call %s failed: %s", func.__name__, e)
+            # getattr, not func.__name__: unittest.mock test doubles don't carry
+            # __name__ unless explicitly configured, and a call that fails to
+            # even be named must not be swallowed for that reason.
+            name = getattr(func, "__name__", repr(func))
+            logger.warning("Garmin API call %s failed: %s", name, e)
+            if failures is not None:
+                failures.append(name)
             return None

--- a/src/mycoach/sources/garmin/source.py
+++ b/src/mycoach/sources/garmin/source.py
@@ -16,6 +16,7 @@ from mycoach.sources.garmin.mappers import (
     import_health_snapshot,
     map_health_snapshot,
     snapshot_has_data,
+    snapshot_null_content_fields,
 )
 
 logger = logging.getLogger(__name__)
@@ -159,6 +160,14 @@ class GarminSource(DataSource):
             logger.warning(
                 "Garmin health fetch for %s: response carried no usable values", day
             )
+        else:
+            null_fields = snapshot_null_content_fields(snapshot)
+            if null_fields:
+                logger.info(
+                    "Garmin health fetch for %s: partial data — null fields: %s",
+                    day,
+                    ", ".join(null_fields),
+                )
         return snapshot, has_data, failures
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-from collections.abc import AsyncGenerator
+import logging
+from collections.abc import AsyncGenerator, Generator
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -17,6 +18,50 @@ async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
 
 
 app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging_state() -> Generator[None, None, None]:
+    """Undo permanent logging mutations so they can't leak into later tests.
+
+    tests/test_migrations/*.py runs real alembic upgrades in-process, and
+    alembic/env.py calls ``logging.config.fileConfig()`` on every invocation.
+    That call defaults to ``disable_existing_loggers=True``, which sets
+    ``.disabled = True`` on *every* logger already registered in
+    ``logging.Logger.manager.loggerDict`` that isn't named in alembic.ini's
+    ``[loggers]`` section (only root/sqlalchemy/alembic are). Because pytest
+    keeps one process for the whole run, this permanently silences
+    already-imported application loggers such as ``mycoach.scheduler.jobs``
+    and ``mycoach.sources.garmin`` — any later test's ``logger.error(...)``
+    call becomes a no-op before a record is ever created, so ``caplog``
+    (which relies on propagation to root) sees nothing.
+
+    Snapshotting the whole loggerDict (name -> disabled/level/propagate/
+    handlers) is cheap — a shallow dict copy — and is the only reliably
+    narrow fix: the set of loggers fileConfig disables is unpredictable
+    (it depends on which modules happened to be imported first), so
+    restoring only a hand-picked list of "loggers production code touches"
+    would not cover it.
+    """
+    manager = logging.Logger.manager
+    root = logging.root
+    snapshot = {
+        name: (lg.disabled, lg.level, lg.propagate, list(lg.handlers))
+        for name, lg in manager.loggerDict.items()
+        if isinstance(lg, logging.Logger)
+    }
+    root_state = (root.disabled, root.level, list(root.handlers))
+    try:
+        yield
+    finally:
+        for name, (disabled, level, propagate, handlers) in snapshot.items():
+            lg = manager.loggerDict.get(name)
+            if isinstance(lg, logging.Logger):
+                lg.disabled = disabled
+                lg.level = level
+                lg.propagate = propagate
+                lg.handlers = handlers
+        root.disabled, root.level, root.handlers = root_state
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_email/test_job_email.py
+++ b/tests/test_email/test_job_email.py
@@ -35,6 +35,10 @@ async def test_daily_briefing_sends_email(mock_session: AsyncMock, mock_insight:
     mock_engine.generate_daily_briefing = AsyncMock(return_value=mock_insight)
 
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
@@ -52,6 +56,10 @@ async def test_daily_briefing_skips_email_when_disabled(
     mock_engine.generate_daily_briefing = AsyncMock(return_value=mock_insight)
 
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),

--- a/tests/test_logging/test_logging_config.py
+++ b/tests/test_logging/test_logging_config.py
@@ -189,6 +189,10 @@ class TestRequestLoggingMiddleware:
             resp = await client.get("/api/health/today")
         # 404 expected (no health data)
         assert resp.status_code == 404
-        matching = [r for r in caplog.records if "/api/health/today" in r.message]
+        matching = [
+            r
+            for r in caplog.records
+            if r.name == "mycoach.access" and "/api/health/today" in r.message
+        ]
         assert len(matching) == 1
         assert "404" in matching[0].message

--- a/tests/test_scheduler/test_job_runs.py
+++ b/tests/test_scheduler/test_job_runs.py
@@ -126,6 +126,10 @@ async def test_daily_briefing_body_records_run() -> None:
     mock_engine.generate_daily_briefing = AsyncMock(return_value=MagicMock())
 
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
@@ -147,6 +151,10 @@ async def test_daily_briefing_body_records_skip() -> None:
     )
 
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", test_session),
     ):
@@ -165,6 +173,10 @@ async def test_daily_briefing_body_records_failure() -> None:
     )
 
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", test_session),
     ):
@@ -504,6 +516,10 @@ def _post_workout_engine() -> MagicMock:
 async def test_records_email_delivered_when_send_succeeds() -> None:
     """A send that reports success records the run as having delivered an email."""
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
@@ -524,6 +540,10 @@ async def test_records_email_not_delivered_when_type_is_disabled() -> None:
     delivery is carried by ``email_delivered``, not by the status.
     """
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
@@ -541,6 +561,10 @@ async def test_records_email_not_delivered_when_type_is_disabled() -> None:
 async def test_rejected_send_fails_the_run_with_the_cause() -> None:
     """A send that is attempted and rejected makes the run a failure."""
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
@@ -564,6 +588,10 @@ async def test_rejected_send_records_the_backend_reason() -> None:
     not have to go back to the logs to learn why the send was refused.
     """
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
@@ -589,6 +617,10 @@ async def test_unattempted_send_records_the_configuration_cause() -> None:
     a configuration fault and must read as one.
     """
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
@@ -607,6 +639,10 @@ async def test_delivery_appears_in_the_structured_log_line(
 ) -> None:
     """The log line carries the delivery fact alongside the other run facts."""
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),

--- a/tests/test_scheduler/test_jobs.py
+++ b/tests/test_scheduler/test_jobs.py
@@ -1,7 +1,7 @@
 """Tests for scheduler job functions."""
 
 import logging
-from datetime import date
+from datetime import date, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -57,6 +57,49 @@ async def test_garmin_sync_success(mock_session: AsyncMock) -> None:
     mock_source.authenticate.assert_awaited_once()
     mock_source.fetch_and_import.assert_awaited_once()
     mock_session.commit.assert_awaited_once()
+
+
+async def test_garmin_sync_looks_back_seven_days_by_default(
+    mock_session: AsyncMock,
+) -> None:
+    """A late Garmin upload must still be recoverable days later."""
+    mock_source = MagicMock()
+    mock_source.authenticate = AsyncMock(return_value=True)
+    mock_result = MagicMock()
+    mock_result.health_snapshots_created = 0
+    mock_result.activities_created = 0
+    mock_source.fetch_and_import = AsyncMock(return_value=mock_result)
+    mock_merge = MagicMock(merged=0)
+
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.merge_garmin_hevy", AsyncMock(return_value=mock_merge)),
+    ):
+        await _garmin_sync()
+
+    since = mock_source.fetch_and_import.await_args.kwargs["since"]
+    assert (datetime.utcnow().date() - since.date()).days == 7
+
+
+async def test_garmin_sync_returns_the_import_result(mock_session: AsyncMock) -> None:
+    """The briefing job needs the result to decide whether to skip."""
+    mock_source = MagicMock()
+    mock_source.authenticate = AsyncMock(return_value=True)
+    mock_result = MagicMock()
+    mock_result.health_snapshots_created = 1
+    mock_result.activities_created = 0
+    mock_source.fetch_and_import = AsyncMock(return_value=mock_result)
+    mock_merge = MagicMock(merged=0)
+
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs.merge_garmin_hevy", AsyncMock(return_value=mock_merge)),
+    ):
+        result = await _garmin_sync()
+
+    assert result is mock_result
 
 
 async def test_garmin_sync_auth_failure_raises(mock_session: AsyncMock) -> None:

--- a/tests/test_scheduler/test_jobs.py
+++ b/tests/test_scheduler/test_jobs.py
@@ -147,6 +147,10 @@ async def test_daily_briefing_success(mock_session: AsyncMock, mock_engine: Magi
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch(
+            "mycoach.scheduler.jobs.get_today_health",
+            AsyncMock(return_value={"sleep_score": 80}),
+        ),
     ):
         await _daily_briefing()
 
@@ -174,6 +178,10 @@ async def test_daily_briefing_syncs_before_generating(
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        patch(
+            "mycoach.scheduler.jobs.get_today_health",
+            AsyncMock(return_value={"sleep_score": 80}),
+        ),
     ):
         await _daily_briefing()
 
@@ -217,10 +225,106 @@ async def test_daily_briefing_proceeds_when_sync_fails(
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        patch(
+            "mycoach.scheduler.jobs.get_today_health",
+            AsyncMock(return_value={"sleep_score": 80}),
+        ),
     ):
         await _daily_briefing()
 
     mock_engine.generate_daily_briefing.assert_awaited_once()
+
+
+async def test_daily_briefing_sync_failure_logged_at_error_level(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A sync failure inside the briefing must not vanish into a WARNING nobody reads.
+
+    R7 says the briefing proceeds regardless — that is pinned by
+    ``test_daily_briefing_proceeds_when_sync_fails`` above and must not change here.
+    This only pins that the failure is loud enough that a 'success' job_runs row
+    is not the only trace of it.
+    """
+
+    async def failing_sync(days: int | None = None) -> MagicMock:
+        raise RuntimeError("Garmin authentication failed")
+
+    mock_engine.generate_daily_briefing = AsyncMock(
+        return_value=MagicMock(content='{"readiness_verdict": "moderate"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", failing_sync),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        patch(
+            "mycoach.scheduler.jobs.get_today_health",
+            AsyncMock(return_value={"sleep_score": 80}),
+        ),
+        caplog.at_level(logging.INFO),
+    ):
+        await _daily_briefing()
+
+    assert any(
+        r.levelno == logging.ERROR and "pre-briefing Garmin sync failed" in r.message
+        for r in caplog.records
+    )
+
+
+async def test_daily_briefing_warns_when_no_recovery_data(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A snapshot with some content but no sleep/HRV/Body Battery must not pass silently.
+
+    The skip guard is deliberately narrow (only a fully empty day skips), so a
+    thin day like this proceeds to generate a briefing — but it must log loudly
+    that it did so without any recovery data.
+    """
+    with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        patch(
+            "mycoach.scheduler.jobs.get_today_health",
+            AsyncMock(return_value={"resting_hr": 58, "steps": 10234}),
+        ),
+        caplog.at_level(logging.INFO),
+    ):
+        await _daily_briefing()
+
+    assert any(
+        r.levelno == logging.WARNING and "without any recovery data" in r.message
+        for r in caplog.records
+    )
+    mock_engine.generate_daily_briefing.assert_awaited_once()
+
+
+async def test_daily_briefing_no_warning_when_sleep_data_present(
+    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The no-recovery-data warning must not fire when sleep data is present."""
+    with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+        patch(
+            "mycoach.scheduler.jobs.get_today_health",
+            AsyncMock(return_value={"resting_hr": 58, "sleep_score": 80}),
+        ),
+        caplog.at_level(logging.INFO),
+    ):
+        await _daily_briefing()
+
+    assert not any("without any recovery data" in r.message for r in caplog.records)
 
 
 async def test_daily_briefing_raises_skip_on_duplicate(
@@ -238,6 +342,10 @@ async def test_daily_briefing_raises_skip_on_duplicate(
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch(
+            "mycoach.scheduler.jobs.get_today_health",
+            AsyncMock(return_value={"sleep_score": 80}),
+        ),
         pytest.raises(PipelineSkip),
     ):
         await _daily_briefing()
@@ -258,6 +366,10 @@ def test_daily_briefing_job_logs_skip(
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch(
+            "mycoach.scheduler.jobs.get_today_health",
+            AsyncMock(return_value={"sleep_score": 80}),
+        ),
         caplog.at_level(logging.INFO),
     ):
         job_daily_briefing()  # must not raise
@@ -289,6 +401,10 @@ def test_daily_briefing_job_logs_malformed_response_as_failure(
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+        patch(
+            "mycoach.scheduler.jobs.get_today_health",
+            AsyncMock(return_value={"sleep_score": 80}),
+        ),
         caplog.at_level(logging.INFO),
     ):
         job_daily_briefing()  # must not raise

--- a/tests/test_scheduler/test_jobs.py
+++ b/tests/test_scheduler/test_jobs.py
@@ -141,8 +141,82 @@ def test_garmin_sync_job_logs_auth_failure(
 async def test_daily_briefing_success(mock_session: AsyncMock, mock_engine: MagicMock) -> None:
     """Daily briefing job should call the coaching engine."""
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+    ):
+        await _daily_briefing()
+
+    mock_engine.generate_daily_briefing.assert_awaited_once()
+
+
+async def test_daily_briefing_syncs_before_generating(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """The briefing must fetch fresh data, not read a snapshot hours old."""
+    calls: list[str] = []
+
+    async def fake_sync(days: int | None = None) -> MagicMock:
+        calls.append("sync")
+        return MagicMock(empty_health_days=[])
+
+    async def fake_generate(*args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append("generate")
+        return MagicMock(content='{"readiness_verdict": "go_hard"}')
+
+    mock_engine.generate_daily_briefing = AsyncMock(side_effect=fake_generate)
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", fake_sync),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _daily_briefing()
+
+    assert calls == ["sync", "generate"]
+
+
+async def test_daily_briefing_skips_when_today_has_no_health_data(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """No data is a skip with a reason — never a briefing invented from nothing."""
+    today = date.today()
+
+    async def fake_sync(days: int | None = None) -> MagicMock:
+        return MagicMock(empty_health_days=[today])
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", fake_sync),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        pytest.raises(PipelineSkip, match="no usable health data"),
+    ):
+        await _daily_briefing()
+
+    mock_engine.generate_daily_briefing.assert_not_awaited()
+
+
+async def test_daily_briefing_proceeds_when_sync_fails(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """A sync failure must not block a briefing when the DB already has data."""
+
+    async def failing_sync(days: int | None = None) -> MagicMock:
+        raise RuntimeError("Garmin authentication failed")
+
+    mock_engine.generate_daily_briefing = AsyncMock(
+        return_value=MagicMock(content='{"readiness_verdict": "moderate"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", failing_sync),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
     ):
         await _daily_briefing()
 
@@ -158,6 +232,10 @@ async def test_daily_briefing_raises_skip_on_duplicate(
     )
 
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         pytest.raises(PipelineSkip),
@@ -174,6 +252,10 @@ def test_daily_briefing_job_logs_skip(
     )
 
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         caplog.at_level(logging.INFO),
@@ -200,6 +282,10 @@ def test_daily_briefing_job_logs_malformed_response_as_failure(
     mock_engine.generate_daily_briefing = AsyncMock(return_value=mock_insight)
 
     with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),

--- a/tests/test_sources/test_garmin.py
+++ b/tests/test_sources/test_garmin.py
@@ -13,6 +13,7 @@ from mycoach.sources.garmin.mappers import (
     import_health_snapshot,
     map_activity,
     map_health_snapshot,
+    snapshot_has_data,
 )
 from mycoach.sources.garmin.source import GarminSource
 
@@ -600,6 +601,36 @@ class TestGarminSource:
             assert result.activities_created == 1
             assert any("Health fetch failed" in e for e in (result.errors or []))
 
+    async def test_null_skeleton_day_is_flagged_as_empty(self, setup_db) -> None:  # type: ignore[no-untyped-def]
+        """A dict-shaped but all-null Garmin response must count as no data."""
+        from tests.conftest import test_session
+
+        mock_client = MagicMock()
+        mock_client.get_stats.return_value = {"calendarDate": "2026-08-14"}
+        mock_client.get_sleep_data.return_value = {"dailySleepDTO": {}}
+        mock_client.get_hrv_data.return_value = {"hrvSummary": {}}
+        mock_client.get_stress_data.return_value = {}
+        mock_client.get_body_battery.return_value = []
+        mock_client.get_training_readiness.return_value = {}
+        mock_client.get_training_status.return_value = {}
+        mock_client.get_max_metrics.return_value = []
+        mock_client.get_respiration_data.return_value = {}
+        mock_client.get_spo2_data.return_value = {}
+        mock_client.get_activities_by_date.return_value = []
+
+        source = GarminSource(client=mock_client)
+
+        async with test_session() as session:
+            user = await _create_user(session)
+            await session.commit()
+
+            result = await source.fetch_and_import(
+                session, user.id, since=datetime(2026, 8, 14)
+            )
+
+            assert result.errors is not None
+            assert any("no usable Garmin health data" in e for e in result.errors)
+
 
 # ── API Endpoint Tests ───────────────────────────────────────────────
 
@@ -656,3 +687,41 @@ class TestSyncGarminEndpoint:
 
         resp = await client.post("/api/sources/sync/garmin?days=14")
         assert resp.status_code == 200
+
+
+class TestSnapshotHasData:
+    def test_all_null_skeleton_has_no_data(self) -> None:
+        """Garmin's empty-day response is a valid dict of nulls — not data."""
+        skeleton = {
+            "restingHeartRate": None,
+            "maxHeartRate": None,
+            "totalSteps": None,
+            "calendarDate": "2026-08-14",
+        }
+        snapshot = map_health_snapshot(
+            user_id=1,
+            snapshot_date=date(2026, 8, 14),
+            stats=skeleton,
+            sleep={"dailySleepDTO": {}},
+            hrv={"hrvSummary": {}},
+        )
+        assert snapshot_has_data(snapshot) is False
+
+    def test_populated_snapshot_has_data(self) -> None:
+        snapshot = map_health_snapshot(
+            user_id=1,
+            snapshot_date=date(2026, 8, 13),
+            stats=SAMPLE_STATS,
+            sleep=SAMPLE_SLEEP,
+        )
+        assert snapshot_has_data(snapshot) is True
+
+    def test_raw_data_alone_is_not_data(self) -> None:
+        """raw_data is always set, so it must not count as content."""
+        snapshot = map_health_snapshot(
+            user_id=1,
+            snapshot_date=date(2026, 8, 14),
+            stats={"calendarDate": "2026-08-14"},
+        )
+        assert snapshot.raw_data is not None
+        assert snapshot_has_data(snapshot) is False

--- a/tests/test_sources/test_garmin.py
+++ b/tests/test_sources/test_garmin.py
@@ -1,8 +1,10 @@
 """Tests for Garmin source: mappers, source orchestration, and sync endpoint."""
 
+import logging
 from datetime import date, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from sqlalchemy import select
 
 from mycoach.models.activity import Activity
@@ -541,6 +543,42 @@ class TestGarminSource:
             assert result.errors is not None
             assert any("no usable Garmin health data" in e for e in result.errors)
 
+    def test_partial_day_logs_which_content_fields_are_null(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A day with some fields but no sleep must log which content came back null.
+
+        The old per-field ``field_status`` INFO log was deleted along with its
+        misleading ``isinstance`` checks, but a *partially*-populated day now
+        logs nothing at all: ``has_data`` is True so the empty-day WARNING never
+        fires, and nothing raised so nothing lands in ``errors``. That silent
+        partial shape is exactly the 13/08 symptom the spec opens with.
+        """
+        mock_client = MagicMock()
+        mock_client.get_stats.return_value = SAMPLE_STATS
+        mock_client.get_sleep_data.return_value = None
+        mock_client.get_hrv_data.return_value = None
+        mock_client.get_stress_data.return_value = None
+        mock_client.get_body_battery.return_value = None
+        mock_client.get_training_readiness.return_value = None
+        mock_client.get_training_status.return_value = None
+        mock_client.get_max_metrics.return_value = None
+        mock_client.get_respiration_data.return_value = None
+        mock_client.get_spo2_data.return_value = None
+
+        source = GarminSource(client=mock_client)
+
+        with caplog.at_level(logging.INFO):
+            _, has_data, failures = source._fetch_health_for_day(1, date(2026, 8, 13))
+
+        assert has_data is True
+        assert failures == []
+        info_logs = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any(
+            "sleep_duration_minutes" in r.message and "partial data" in r.message
+            for r in info_logs
+        )
+
     async def test_auth_failure(self, setup_db) -> None:  # type: ignore[no-untyped-def]
         mock_client = MagicMock()
         mock_client.connect.return_value = False
@@ -786,3 +824,24 @@ class TestSnapshotHasData:
         )
         assert snapshot.raw_data is not None
         assert snapshot_has_data(snapshot) is False
+
+    def test_zero_valued_metric_counts_as_data(self) -> None:
+        """A zero is a real reading, not Garmin's null skeleton.
+
+        ``_safe_int(0)`` returns ``0``, not ``None``, so a snapshot whose only
+        non-null value is a zero-valued metric (e.g. a genuine 0-step rest day)
+        is treated as data. This is the intended behaviour: Garmin's actual
+        empty-day payload is all-null, never a zero — a zero means Garmin
+        answered with a real, if uneventful, value. Treating it as "no data"
+        would wrongly skip a briefing for a day Garmin did answer. If Garmin
+        ever sends a zero to *mean* "no reading" this pins the fact that
+        ``snapshot_has_data`` would score it as data anyway, so a future fix
+        for that must touch this test.
+        """
+        snapshot = map_health_snapshot(
+            user_id=1,
+            snapshot_date=date(2026, 8, 14),
+            stats={"totalSteps": 0},
+        )
+        assert snapshot.steps == 0
+        assert snapshot_has_data(snapshot) is True

--- a/tests/test_sources/test_garmin.py
+++ b/tests/test_sources/test_garmin.py
@@ -631,6 +631,67 @@ class TestGarminSource:
             assert result.errors is not None
             assert any("no usable Garmin health data" in e for e in result.errors)
 
+    async def test_empty_days_exposed_as_structured_dates(self, setup_db) -> None:  # type: ignore[no-untyped-def]
+        """Callers must be able to ask 'was this day empty?' without parsing prose."""
+        from tests.conftest import test_session
+
+        mock_client = MagicMock()
+        mock_client.get_stats.return_value = {"calendarDate": "2026-08-14"}
+        mock_client.get_sleep_data.return_value = {}
+        mock_client.get_hrv_data.return_value = {}
+        mock_client.get_stress_data.return_value = {}
+        mock_client.get_body_battery.return_value = []
+        mock_client.get_training_readiness.return_value = {}
+        mock_client.get_training_status.return_value = {}
+        mock_client.get_max_metrics.return_value = []
+        mock_client.get_respiration_data.return_value = {}
+        mock_client.get_spo2_data.return_value = {}
+        mock_client.get_activities_by_date.return_value = []
+
+        source = GarminSource(client=mock_client)
+
+        async with test_session() as session:
+            user = await _create_user(session)
+            await session.commit()
+
+            result = await source.fetch_and_import(
+                session, user.id, since=datetime(2026, 8, 14)
+            )
+
+            assert date(2026, 8, 14) in result.empty_health_days
+
+    async def test_api_exception_reported_separately_from_emptiness(self, setup_db) -> None:  # type: ignore[no-untyped-def]
+        """A crashed endpoint must not masquerade as a day with no data."""
+        from tests.conftest import test_session
+
+        mock_client = MagicMock()
+        mock_client.get_stats.return_value = SAMPLE_STATS
+        mock_client.get_sleep_data.side_effect = RuntimeError("401 Unauthorized")
+        mock_client.get_hrv_data.return_value = SAMPLE_HRV
+        mock_client.get_stress_data.return_value = SAMPLE_STRESS
+        mock_client.get_body_battery.return_value = SAMPLE_BODY_BATTERY
+        mock_client.get_training_readiness.return_value = SAMPLE_TRAINING_READINESS
+        mock_client.get_training_status.return_value = SAMPLE_TRAINING_STATUS
+        mock_client.get_max_metrics.return_value = SAMPLE_MAX_METRICS
+        mock_client.get_respiration_data.return_value = SAMPLE_RESPIRATION
+        mock_client.get_spo2_data.return_value = SAMPLE_SPO2
+        mock_client.get_activities_by_date.return_value = []
+
+        source = GarminSource(client=mock_client)
+
+        async with test_session() as session:
+            user = await _create_user(session)
+            await session.commit()
+
+            result = await source.fetch_and_import(
+                session, user.id, since=datetime(2026, 8, 14)
+            )
+
+            assert result.errors is not None
+            assert any("get_sleep_data" in e for e in result.errors)
+            # The day still had other content, so it is not an "empty" day.
+            assert result.empty_health_days == []
+
 
 # ── API Endpoint Tests ───────────────────────────────────────────────
 


### PR DESCRIPTION
## The bug

The daily briefing's `## Today's Health Data` section was empty (14/08, 15/08) or carried only a thin subset — resting HR, max HR, stress, SpO2, with no sleep, HRV or Body Battery (13/08). The briefing exists to assess last night's sleep and recovery, so it was producing readiness verdicts from nothing.

## Diagnosis

Evidence gathered against the production container. Full write-up in `docs/superpowers/specs/2026-08-16-daily-briefing-stale-health-data.md`.

**Root cause — we asked Garmin before Garmin had the answer.** `garmin_sync` fires at 06:00 Europe/London. At that hour the watch hasn't pushed the night, and Garmin answers with an *all-null skeleton*: a ~6 KB JSON document with `calendarDate` set and every metric `null`. That got mapped to an all-NULL snapshot row. The briefing then ran at 09:30 and read that row — nothing re-synced in between.

The 13/08 row proves it: partial in its own 08:30 briefing, complete in the DB now (sleep score 80, HRV 73, Body Battery 92). The data existed; the briefing never saw it.

**Compounding — a 2-day lookback that closed the window.** The 14/08 data reached Garmin during the 15th, ~18h after that morning's sync had already asked and been told "nothing". One more day and it would have fallen permanently outside the window. A manual sync at 23:50 on the 15th confirmed it: `raw_data` for 14/08 went from 6,290 B of nulls to 268,857 B of real values.

**Why it went unnoticed for days.** Three silences: `_safe_call` swallowed every exception into `None`; the `field_status` logging was an `isinstance(x, dict)` **type** check that scored the all-null skeleton as `'sleep': True`, logging identically on rich days and empty ones; and `has_data = any(field_status.values())` therefore never fired, so `job_runs.error` stayed blank and every run reported `success`.

## Changes

| Commit | What |
|---|---|
| `a3e2f24` | Judge day emptiness by mapped snapshot **content**, not response **type** |
| `9e93386` | Expose `empty_health_days` as structured dates; report API crashes separately from empty days |
| `b9427e5` | Widen sync lookback 2 → 7 days, configurable |
| `ca690a7` | **Briefing syncs Garmin before generating; skips with a recorded reason when today is empty** |
| `65b3d46` | Scheduler docs match the new arrangement |
| `9acdfb5` | Surface silent sync failures and thin recovery data |
| `188e1ec` | Restore logging state between tests |

### Notes on two of them

`a3e2f24` excludes `raw_data` from the content check — it is written even for the null skeleton, so leaving it in would have reproduced the original bug through a new mechanism. There's a test pinning that.

`188e1ec` fixes a pre-existing test-isolation bug that predates this branch: `alembic/env.py` calls `fileConfig()`, whose `disable_existing_loggers` defaults to `True`, so running a migration in-process permanently disabled every application logger absent from `alembic.ini` — starving `caplog` in 13 order-dependent tests. The suite went from 10 pre-existing failures to **0**.

## Behaviour changes

- The briefing now performs its own Garmin sync before generating, so it reads data minutes old rather than 3.5 hours old.
- On a day where Garmin genuinely returns nothing, the briefing **skips** (`job_runs.status='skipped'` with a reason naming the date) instead of generating a fabricated verdict.
- A sync failure does **not** block the briefing — yesterday's data may be enough — but is now logged at `ERROR` rather than `WARNING`.
- A partial day, and a day with no sleep/HRV/Body Battery, now log explicitly instead of passing silently.

## Testing

626 passing, 0 failures. Verified stable across three orderings, including with random ordering disabled.

## Still to verify in production

After deploy, the `## Today's Health Data` section should list `Sleep score`, `HRV` and `Body Battery (morning)`. Note that a briefing already exists for today after a normal run, so forcing a regeneration means deleting today's insight first.

## Backlog (agreed, not in this PR)

- User-facing staleness alert ("no Garmin data in N days").
- The briefing's inline sync re-fetches 7 days, hours after the 06:00 job did the same (~70 redundant HTTP calls/day). Deliberately left at 7 for maximum late-upload recovery; `_garmin_sync` is parameterised if that ever needs revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcmRYqQoyTRRyh1RMWfWRG
