### PR TITLE
Retry the daily briefing across a window instead of once at 09:30

### DIFF
--- a/src/mycoach/api/pages/dashboard.py
+++ b/src/mycoach/api/pages/dashboard.py
@@ -10,10 +10,13 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from mycoach.coaching.context import get_today_health
+from mycoach.coaching.recovery_data import missing_recovery_data
 from mycoach.database import get_db
 from mycoach.models.coaching import CoachingInsight
 from mycoach.models.health import DailyHealthSnapshot
 from mycoach.models.plan import PlannedSession, WeeklyPlan
+from mycoach.scheduler.briefing_window import load_briefing_window
 
 router = APIRouter(tags=["pages"])
 
@@ -141,12 +144,28 @@ async def dashboard(
         )
     )
 
+    # Why there is no briefing, straight from the retry loop's own record. The
+    # page is server-rendered Jinja and job_runs is an ordinary table, so this
+    # is one query rather than a new API endpoint.
+    briefing_banner = None
+    if briefing is None:
+        window = await load_briefing_window(session)
+        briefing_banner = window.banner
+
+    # And why the Generate button would refuse — the same guard the endpoint
+    # behind the button now enforces, asked before the click rather than after.
+    briefing_blocked_reason = missing_recovery_data(
+        await get_today_health(session, USER_ID, today)
+    )
+
     templates: Jinja2Templates = request.app.state.templates
 
     return templates.TemplateResponse(
         request,
         "dashboard.html",
         {
+            "briefing_banner": briefing_banner,
+            "briefing_blocked_reason": briefing_blocked_reason,
             "active_page": "dashboard",
             "today_str": today.strftime("%B %d, %Y"),
             "weekday": DAY_NAMES[weekday_num],

--- a/src/mycoach/api/routes/coaching.py
+++ b/src/mycoach/api/routes/coaching.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from mycoach.coaching.engine import CoachingEngine
-from mycoach.coaching.exceptions import PipelineSkip
+from mycoach.coaching.exceptions import InsufficientHealthData, PipelineSkip
 from mycoach.database import get_db
 from mycoach.models.coaching import CoachingInsight
 from mycoach.schemas.coaching import CoachingInsightRead
@@ -48,11 +48,18 @@ async def generate_today_briefing(
     """Generate today's daily coaching briefing.
 
     Gathers health + activity data, calls the LLM, and stores the result.
-    Returns 409 if a briefing already exists for today (unless force=true).
+    Returns 409 if a briefing already exists for today, and 422 if today has no
+    recovery data to brief on — both released by force=true, which is the one
+    documented way to override the guards.
     """
     engine = CoachingEngine()
     try:
         insight = await engine.generate_daily_briefing(session, USER_ID, force=force)
+    except InsufficientHealthData as e:
+        # 422, not 409: nothing already exists, the request simply cannot be
+        # satisfied from today's data. Naming what is missing is the point —
+        # the dashboard shows this text verbatim.
+        raise HTTPException(status_code=422, detail=str(e)) from None
     except (PipelineSkip, ValueError) as e:
         raise HTTPException(status_code=409, detail=str(e)) from None
     except RuntimeError as e:

--- a/src/mycoach/coaching/engine.py
+++ b/src/mycoach/coaching/engine.py
@@ -30,7 +30,11 @@ from mycoach.coaching.context import (
     get_today_planned_sessions,
     link_activity_to_planned_session,
 )
-from mycoach.coaching.exceptions import NoAvailabilityConfigured, PipelineSkip
+from mycoach.coaching.exceptions import (
+    InsufficientHealthData,
+    NoAvailabilityConfigured,
+    PipelineSkip,
+)
 from mycoach.coaching.llm_client import LLMClient, LLMResponse, get_llm_client
 from mycoach.coaching.prompt_builder import (
     build_cardio_plan_prompt,
@@ -40,6 +44,7 @@ from mycoach.coaching.prompt_builder import (
     build_weekly_recap_prompt,
     get_system_prompt,
 )
+from mycoach.coaching.recovery_data import missing_recovery_data
 from mycoach.coaching.response_parser import (
     CardioPlanResponse,
     DailyBriefingResponse,
@@ -102,6 +107,16 @@ class CoachingEngine:
 
         # Gather context
         health_today = await get_today_health(session, user_id, today)
+
+        # The empty-data guard lives here, not in the scheduler job, so cron,
+        # retry loop and dashboard button cannot drift apart on what counts as
+        # a day worth briefing about. ``force`` remains the explicit escape
+        # hatch, as it is for the already-exists check above.
+        if not force:
+            missing = missing_recovery_data(health_today)
+            if missing is not None:
+                raise InsufficientHealthData(missing)
+
         health_trends = await get_health_trends(session, user_id, days=3, today=today)
         recent_activities = await get_recent_activities(session, user_id, days=3, today=today)
         planned_sessions = await get_today_planned_sessions(session, user_id, today)

--- a/src/mycoach/coaching/exceptions.py
+++ b/src/mycoach/coaching/exceptions.py
@@ -20,3 +20,15 @@ class NoAvailabilityConfigured(PipelineSkip):
     specifically (e.g. sending a "we couldn't plan your week" email) without
     parsing the skip message.
     """
+
+
+class InsufficientHealthData(PipelineSkip):
+    """Raised when the day has no recovery data to build a briefing from.
+
+    A subtype of ``PipelineSkip`` because withholding the briefing is the
+    correct no-op, not a fault — but distinguished from a plain skip because
+    callers must react differently: the manual endpoint answers 422 (the day
+    cannot support the request) rather than 409 (the briefing already exists),
+    and the retry loop keeps retrying this outcome while a real failure burns
+    the failure budget.
+    """

--- a/src/mycoach/coaching/recovery_data.py
+++ b/src/mycoach/coaching/recovery_data.py
@@ -1,0 +1,42 @@
+"""The rule that decides whether a day's health data can support a briefing.
+
+Lives in its own module rather than inside the scheduler job that first needed
+it, because three callers have to agree on the answer: the retry loop, the
+manual generate endpoint, and the dashboard button that offers the manual
+endpoint. When the rule lived in the job, the manual path bypassed it — for six
+days the dashboard invited the user to press a button that would have produced a
+briefing from a snapshot carrying nothing but a display name.
+"""
+
+from typing import Any
+
+# The fields that make a briefing about recovery rather than about nothing —
+# sleep, HRV, and Body Battery. A snapshot can carry *some* content (resting HR,
+# steps) while holding none of these, which is not "no data" but is still
+# nothing to coach from.
+RECOVERY_FIELDS = (
+    "sleep_duration_minutes",
+    "sleep_score",
+    "hrv_status",
+    "hrv_7day_avg",
+    "hrv_status_text",
+    "body_battery_morning",
+)
+
+
+def missing_recovery_data(health_today: dict[str, Any]) -> str | None:
+    """Why today's health data cannot support a briefing, or None if it can.
+
+    Returns a sentence naming what is absent, so every caller reports the same
+    reason: the run's ``skip_reason``, the 422 body, and the dashboard banner.
+    """
+    if any(health_today.get(field) is not None for field in RECOVERY_FIELDS):
+        return None
+    if not health_today:
+        return (
+            "no Garmin health snapshot for today — nothing to base a briefing on"
+        )
+    return (
+        "today's Garmin health snapshot carries no sleep, HRV, or Body Battery "
+        "data — nothing to base a briefing on"
+    )

--- a/src/mycoach/config.py
+++ b/src/mycoach/config.py
@@ -74,6 +74,12 @@ class Settings(BaseSettings):
     scheduler_sync_lookback_days: int = 7
     scheduler_briefing_hour: int = 9
     scheduler_briefing_minute: int = 30
+    # The briefing's own pre-generation sync, which runs on every tick of the
+    # 15-minute retry poll rather than once a day. Deliberately far narrower
+    # than scheduler_sync_lookback_days above: recovering a five-day-old late
+    # upload is the 06:00 sync's job, and re-asking for it forty times a day
+    # only risks throttling the account the poll depends on.
+    scheduler_briefing_sync_lookback_days: int = 2
     scheduler_post_workout_hour: int = 7
     scheduler_post_workout_minute: int = 0
     scheduler_weekly_plan_day: str = "sun"

--- a/src/mycoach/email/sender.py
+++ b/src/mycoach/email/sender.py
@@ -6,9 +6,11 @@ Backend is selected based on configuration: Resend API key takes precedence over
 
 import logging
 import smtplib
+from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import resend
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -273,6 +275,96 @@ def send_no_availability(week_start: str, settings: Settings | None = None) -> b
         },
     )
     return send_email(settings.email_to, "MyCoach — No Plan Generated", html, settings)
+
+
+def _format_last_upload(uploaded_at: datetime, settings: Settings) -> str:
+    """Render a last-upload timestamp in the user's timezone, e.g. "Aug 19 at 05:20"."""
+    local = uploaded_at.astimezone(ZoneInfo(settings.timezone))
+    return local.strftime("%b %-d at %H:%M")
+
+
+def send_briefing_unavailable(
+    day: str,
+    failures: int,
+    is_broken: bool,
+    can_still_retry: bool,
+    detail: str | None = None,
+    last_upload: datetime | None = None,
+    device_name: str | None = None,
+    settings: Settings | None = None,
+) -> bool:
+    """Tell the user why there is no briefing this morning.
+
+    The wording turns entirely on ``is_broken``, because the two causes need
+    opposite things from the reader. Absent data is theirs to fix — the watch
+    uploads over Bluetooth only, so the actionable fact is when it last reached
+    Garmin at all. A broken pipeline is ours; telling someone to check their
+    Bluetooth when the real fault was a validation error in our own code is
+    worse than sending nothing, so that branch says so plainly and names the
+    error instead.
+
+    ``failures`` counts errors only, never skips. A morning of four data-less
+    skips followed by one real error is one error, and telling the reader we
+    hit five would send them looking for a fault that isn't there. The
+    data-absent branches quote no count at all: how many times we asked is our
+    business, and the reader can only act on when their watch last synced.
+    """
+    if settings is None:
+        settings = get_settings()
+
+    if is_broken:
+        attempt_word = "attempt" if failures == 1 else "attempts"
+        headline = (
+            f"MyCoach could not generate your briefing this morning — "
+            f"{failures} {attempt_word} hit an error. This is a fault on our "
+            f"side, not with your watch."
+        )
+    elif last_upload is not None:
+        headline = (
+            f"Your watch hasn't uploaded to Garmin since "
+            f"{_format_last_upload(last_upload, settings)}. Check that Bluetooth is "
+            f"on and that the Garmin Connect app has synced — MyCoach has nothing "
+            f"to read your recovery from until it does."
+        )
+    else:
+        headline = (
+            "Garmin still has no recovery data for today. Check that Bluetooth "
+            "is on and that the Garmin Connect app has synced."
+        )
+
+    if can_still_retry:
+        next_step = (
+            "MyCoach will keep checking every 15 minutes and will send your briefing "
+            "as soon as the data lands. It stops generating at 14:00 — a briefing "
+            "about this morning's recovery isn't worth much by the evening."
+        )
+    elif is_broken:
+        next_step = (
+            "Retries have stopped for today, so no further attempt will be made "
+            "automatically. The dashboard's regenerate button still works once "
+            "the cause is fixed."
+        )
+    else:
+        next_step = (
+            "The 14:00 cutoff has passed, so no briefing will be generated for "
+            "today. Tomorrow's runs as normal once your watch has synced."
+        )
+
+    html = _render_template(
+        "briefing_unavailable.html",
+        {
+            "day": day,
+            "headline": headline,
+            "next_step": next_step,
+            "detail": detail,
+            "last_upload": (
+                _format_last_upload(last_upload, settings) if last_upload else None
+            ),
+            "device_name": device_name,
+            "dashboard_url": _dashboard_url(settings),
+        },
+    )
+    return send_email(settings.email_to, "MyCoach — No Briefing Today", html, settings)
 
 
 def send_post_workout(content: dict, activity_title: str, settings: Settings | None = None) -> bool:  # type: ignore[type-arg]

--- a/src/mycoach/email/templates/briefing_unavailable.html
+++ b/src/mycoach/email/templates/briefing_unavailable.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block title %}No Briefing Today{% endblock %}
+{% block subtitle %}No briefing today{% endblock %}
+{% block content %}
+
+<!-- Hero -->
+<tr>
+  <td class="px" style="padding-top:26px;padding-bottom:18px;">
+    <div class="eyebrow">{{ day }}</div>
+    <div class="verdict" style="font-size:32px;margin-top:10px;">No briefing yet</div>
+    <div class="rule" style="margin-top:16px;">&nbsp;</div>
+    <div class="lead" style="margin-top:14px;">{{ headline }}</div>
+  </td>
+</tr>
+
+{% if last_upload %}
+<!-- The one fact the reader can act on -->
+<tr>
+  <td class="px" style="padding-top:6px;padding-bottom:6px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-top:1px solid rgba(0,0,0,.08);">
+      <tr>
+        <td class="mrow mlabel" style="padding:12px 0;">Last upload</td>
+        <td class="mrow mval" style="padding:12px 0;">{{ last_upload }}</td>
+      </tr>
+      {% if device_name %}
+      <tr>
+        <td class="mrow mlabel" style="padding:12px 0;">Device</td>
+        <td class="mrow mval" style="padding:12px 0;">{{ device_name }}</td>
+      </tr>
+      {% endif %}
+    </table>
+  </td>
+</tr>
+{% endif %}
+
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">What happens next</div>
+    <div class="p">{{ next_step }}</div>
+  </td>
+</tr>
+
+{% if detail %}
+<tr>
+  <td class="px block-b" style="padding-top:20px;padding-bottom:2px;">
+    <div class="sec" style="margin-bottom:8px;">Detail</div>
+    <div class="p">{{ detail }}</div>
+  </td>
+</tr>
+{% endif %}
+
+<tr>
+  <td class="px" style="padding-top:22px;padding-bottom:28px;">
+    <a href="{{ dashboard_url|default('#') }}" class="cta">Open the dashboard &rarr;</a>
+  </td>
+</tr>
+{% endblock %}

--- a/src/mycoach/models/job_run.py
+++ b/src/mycoach/models/job_run.py
@@ -9,9 +9,17 @@ from mycoach.database import Base
 class JobRun(Base):
     """Durable record of a single scheduled-job execution.
 
-    Append-only, write-only exhaust: nothing in the coaching, source, or
-    scheduler logic ever reads it. Idempotency comes from checking for existing
-    insights, never from querying run history.
+    Append-only, and — since the daily-briefing retry window — no longer
+    write-only. ``mycoach.scheduler.briefing_window`` derives that window's
+    entire state from these rows: whether today's briefing has succeeded, how
+    many attempts have been made since the window opened, whether each ended in
+    a skip or a real failure, and whether the user has already been emailed.
+
+    That is deliberate rather than convenient. The scheduler has no jobstore and
+    rebuilds its jobs on every boot, so anything held in memory is lost to a
+    container restart; a table already written on every run is the only place
+    the state can live without inventing one. Idempotency for *insights* still
+    comes from checking for the insight itself, never from run history.
     """
 
     __tablename__ = "job_runs"

--- a/src/mycoach/scheduler/briefing_window.py
+++ b/src/mycoach/scheduler/briefing_window.py
@@ -1,0 +1,307 @@
+"""What the daily-briefing retry loop should do right now, read off ``job_runs``.
+
+A briefing used to be generated once, at 09:30, and a day where Garmin had not
+yet uploaded produced a skip that was both invisible and final. The watch
+uploads over Bluetooth only, and even a healthy one lands its data anywhere
+between 05:09 and 17:44 — so a single attempt loses roughly one briefing in
+five to timing alone, and a backlogged one loses days at a stretch.
+
+The fix is a poll: try every 15 minutes from the configured briefing time,
+generate on the first attempt that has usable data, and email the user if the
+data still has not arrived an hour in.
+
+**All state is derived, none is held.** Every question this module answers —
+"has a briefing succeeded today?", "how many attempts since the window
+opened?", "have we already emailed?" — is a query against ``job_runs``, an
+append-only table already written on every run. That is a hard requirement
+rather than a preference: the scheduler has no jobstore and rebuilds its jobs
+from ``create_scheduler()`` on every boot, so in-memory retry state would mean
+either a duplicate briefing or a silently dropped window each time the
+container restarts. The container did restart mid-incident.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from mycoach.config import Settings, get_settings
+from mycoach.models.coaching import CoachingInsight
+from mycoach.models.job_run import JobRun
+
+logger = logging.getLogger(__name__)
+
+USER_ID = 1  # Single-user MVP
+
+BRIEFING_JOB = "daily_briefing"
+BRIEFING_ALERT_JOB = "daily_briefing_alert"
+
+#: Stop *generating* here. A briefing about this morning's recovery delivered
+#: at 18:00 is wrong, not late.
+GENERATE_CUTOFF = time(14, 0)
+
+#: Stop *evaluating* here. Between the two cutoffs the loop no longer tries to
+#: generate but still watches, so a day that never got data is still alerted on.
+EVALUATE_CUTOFF = time(20, 0)
+
+#: Poll interval, in minutes. Must divide 60 — the cron trigger is built from it.
+POLL_INTERVAL_MINUTES = 15
+
+#: Attempts that must pass before the user is emailed. Four polls at 15-minute
+#: spacing is a one-hour grace period, which kills essentially every false alarm
+#: in the observed history while still leaving time to fix a phone-side sync and
+#: get a real briefing before the 14:00 cutoff.
+ALERT_AFTER_ATTEMPTS = 4
+
+#: How many *failed* attempts (as opposed to skips) to allow before giving up on
+#: generating. A skip means the data has not arrived and may yet; a failure means
+#: the pipeline is broken, and re-running a broken pipeline every 15 minutes
+#: until 14:00 burns LLM spend to reproduce the same stack trace.
+MAX_FAILED_ATTEMPTS = 3
+
+
+@dataclass(frozen=True)
+class BriefingWindow:
+    """Today's briefing state as of ``now``, and what follows from it.
+
+    Built by :func:`load_briefing_window`; the properties are pure functions of
+    the fields, so the decision logic is testable without a database and the
+    dashboard can render exactly what the scheduler acted on.
+    """
+
+    now: datetime
+    """Local wall-clock time the decision is being made at."""
+
+    day: date
+    """The local date being briefed. Today only — an older day is never
+    backfilled, because a briefing about a past morning is not a briefing."""
+
+    opens_at: time
+    """When the window opened — the configured briefing time."""
+
+    succeeded: bool
+    """Today has a briefing — either a ``daily_briefing`` run reached ``success``
+    or the insight simply exists, which is what a press of the dashboard's
+    button leaves behind. Reading both is the same lesson as the unified data
+    guard: the manual path and the scheduled path must not be able to disagree,
+    or the loop would spend the rest of the morning re-syncing Garmin and
+    recording duplicate skips against a briefing the user already has."""
+
+    skipped_attempts: int
+    """Attempts that ended in ``skipped`` — no usable data yet."""
+
+    failed_attempts: int
+    """Attempts that ended in ``failed`` — the pipeline itself broke."""
+
+    last_status: str | None
+    """Status of the most recent attempt today, or None if there was none."""
+
+    last_detail: str | None
+    """Skip reason or error of the most recent attempt, whichever applies."""
+
+    alerted: bool
+    """Today's alert is settled — it went out, or there was deliberately none to
+    send (the user has briefing email switched off). Either way the matter is
+    closed for the day; only a send that actually *failed* is worth retrying."""
+
+    alert_failures: int
+    """Alert sends that were attempted and refused. Budgeted like generation
+    failures, so a misconfigured email backend cannot turn a 15-minute poll into
+    forty rejected sends a day."""
+
+    @property
+    def attempts(self) -> int:
+        """Every attempt made today, however it ended."""
+        return self.skipped_attempts + self.failed_attempts
+
+    @property
+    def is_open(self) -> bool:
+        """Has the window opened and not yet closed for evaluation?"""
+        return self.opens_at <= self.now.time() < EVALUATE_CUTOFF
+
+    @property
+    def budget_exhausted(self) -> bool:
+        """Have real failures used up the retry budget?"""
+        return self.failed_attempts >= MAX_FAILED_ATTEMPTS
+
+    @property
+    def should_generate(self) -> bool:
+        """Should this poll attempt a briefing?"""
+        return (
+            not self.succeeded
+            and self.is_open
+            and self.now.time() < GENERATE_CUTOFF
+            and not self.budget_exhausted
+        )
+
+    @property
+    def should_alert(self) -> bool:
+        """Should this poll email the user?
+
+        Once per day at most. Normally that means waiting out the grace period,
+        but two other states alert regardless of how few attempts have been
+        made, because in both of them no further attempt is coming:
+
+        * the failure budget is spent — three failures stop generation at three
+          attempts, one short of the grace period, so keying only off the
+          attempt count would leave a broken pipeline silent all day; and
+        * the 14:00 cutoff has passed without a briefing — including the case
+          where the container was down all morning and made no attempt at all.
+
+        Silence in either case is the exact fault this whole window exists to
+        remove.
+        """
+        return (
+            not self.succeeded
+            and not self.alerted
+            and self.alert_failures < MAX_FAILED_ATTEMPTS
+            and self.is_open
+            and (
+                self.attempts >= ALERT_AFTER_ATTEMPTS
+                or self.budget_exhausted
+                or self.now.time() >= GENERATE_CUTOFF
+            )
+        )
+
+    @property
+    def banner(self) -> str | None:
+        """What the dashboard should say about today's briefing, or None.
+
+        The dashboard used to render one fixed sentence — "Sync your Garmin
+        data, then generate today's read" — while the sync had in fact
+        succeeded and the watch was the thing at fault. Rendering this instead
+        means the page tells the same story as ``job_runs``, continuously, from
+        the moment the window opens.
+
+        None means there is nothing to say: the briefing exists, the window has
+        not opened, or nothing has been attempted yet. That last case covers a
+        morning the container slept through, which the page deliberately does
+        *not* claim to explain — with no runs recorded there is nothing to
+        report, and a fresh install with no Garmin account at all would read
+        the same. ``should_alert`` covers that day by email, where the silence
+        actually mattered.
+        """
+        if self.succeeded or self.attempts == 0 or self.now.time() < self.opens_at:
+            return None
+
+        detail = f" Last attempt: {self.last_detail}" if self.last_detail else ""
+
+        if self.budget_exhausted:
+            return (
+                f"Briefing generation failed {self.failed_attempts} times today and "
+                f"retries have stopped.{detail}"
+            )
+        if self.is_broken:
+            # failed_attempts, not attempts: the budget counts failures only, so
+            # a day of skips with one error must not read "attempt 4 of 3".
+            return (
+                f"Briefing generation hit an error ({self.failed_attempts} of "
+                f"{MAX_FAILED_ATTEMPTS} allowed); MyCoach will try again shortly."
+                f"{detail}"
+            )
+        if self.now.time() >= GENERATE_CUTOFF:
+            return (
+                f"Garmin never returned today's recovery data — {self.attempts} "
+                f"attempts up to the {GENERATE_CUTOFF:%H:%M} cutoff. Check that your "
+                f"watch has synced; tomorrow's briefing runs as normal."
+            )
+        return (
+            f"Waiting on Garmin: {self.attempts} attempt(s) since "
+            f"{self.opens_at:%H:%M} found no sleep, HRV, or Body Battery data for "
+            f"today. Retrying every {POLL_INTERVAL_MINUTES} minutes until "
+            f"{GENERATE_CUTOFF:%H:%M}."
+        )
+
+    @property
+    def is_broken(self) -> bool:
+        """Is the outstanding problem a broken pipeline rather than absent data?
+
+        Drives the wording of both the email and the dashboard banner. Telling
+        someone to check their Bluetooth when the real fault was a validation
+        error inside our own pipeline is worse than telling them nothing.
+        """
+        return self.last_status == "failed"
+
+
+async def load_briefing_window(
+    session: AsyncSession,
+    now: datetime | None = None,
+    settings: Settings | None = None,
+) -> BriefingWindow:
+    """Read today's ``job_runs`` and build the window state from them.
+
+    ``now`` defaults to the current time in the scheduler's timezone. The same
+    timezone fixes which local day is "today" and therefore which runs count,
+    so a poll and the dashboard rendered a second apart cannot disagree.
+    """
+    settings = settings or get_settings()
+    tz = ZoneInfo(settings.scheduler_timezone or settings.timezone)
+    now = now or datetime.now(tz)
+    day = now.date()
+    opens_at = time(settings.scheduler_briefing_hour, settings.scheduler_briefing_minute)
+
+    runs = await _runs_on_local_day(session, day, tz)
+    briefing_exists = await _briefing_exists(session, day)
+
+    briefing_runs = [r for r in runs if r.job_name == BRIEFING_JOB]
+    alert_runs = [r for r in runs if r.job_name == BRIEFING_ALERT_JOB]
+    last = briefing_runs[-1] if briefing_runs else None
+
+    return BriefingWindow(
+        now=now,
+        day=day,
+        opens_at=opens_at,
+        succeeded=briefing_exists or any(r.status == "success" for r in briefing_runs),
+        skipped_attempts=sum(1 for r in briefing_runs if r.status == "skipped"),
+        failed_attempts=sum(1 for r in briefing_runs if r.status == "failed"),
+        last_status=last.status if last else None,
+        last_detail=(last.error or last.skip_reason) if last else None,
+        alerted=any(r.status != "failed" for r in alert_runs),
+        alert_failures=sum(1 for r in alert_runs if r.status == "failed"),
+    )
+
+
+async def _briefing_exists(session: AsyncSession, day: date) -> bool:
+    """Is there already a daily briefing for ``day``?
+
+    Scoped to the user the scheduler runs as. Single-user MVP, matching every
+    other scheduler-side query.
+    """
+    found = await session.scalar(
+        select(CoachingInsight.id).where(
+            CoachingInsight.user_id == USER_ID,
+            CoachingInsight.insight_date == day,
+            CoachingInsight.insight_type == BRIEFING_JOB,
+        )
+    )
+    return found is not None
+
+
+async def _runs_on_local_day(
+    session: AsyncSession, day: date, tz: ZoneInfo
+) -> list[JobRun]:
+    """Briefing and alert runs that started on ``day`` in ``tz``, oldest first.
+
+    ``JobRun.started_at`` is a naive UTC timestamp, so the local day's bounds
+    are converted to UTC before comparison rather than the column being
+    converted per row — the latter cannot use an index and, on SQLite, has no
+    timezone-aware function to do it with anyway.
+    """
+    local_start = datetime.combine(day, time.min, tzinfo=tz)
+    local_end = local_start + timedelta(days=1)
+    utc_start = local_start.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+    utc_end = local_end.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+
+    result = await session.execute(
+        select(JobRun)
+        .where(
+            JobRun.job_name.in_((BRIEFING_JOB, BRIEFING_ALERT_JOB)),
+            JobRun.started_at >= utc_start,
+            JobRun.started_at < utc_end,
+        )
+        .order_by(JobRun.started_at, JobRun.id)
+    )
+    return list(result.scalars().all())

--- a/src/mycoach/scheduler/jobs.py
+++ b/src/mycoach/scheduler/jobs.py
@@ -17,13 +17,17 @@ from functools import partial
 
 from sqlalchemy import select
 
-from mycoach.coaching.context import get_today_health
 from mycoach.coaching.engine import CoachingEngine
-from mycoach.coaching.exceptions import NoAvailabilityConfigured, PipelineSkip
+from mycoach.coaching.exceptions import (
+    InsufficientHealthData,
+    NoAvailabilityConfigured,
+    PipelineSkip,
+)
 from mycoach.config import get_settings
 from mycoach.database import async_session
 from mycoach.email.sender import (
     EmailSendError,
+    send_briefing_unavailable,
     send_daily_briefing,
     send_no_availability,
     send_post_workout,
@@ -35,8 +39,15 @@ from mycoach.models.coaching import CoachingInsight
 from mycoach.models.job_run import JobRun
 from mycoach.models.plan import PlannedSession
 from mycoach.models.user import User
+from mycoach.scheduler.briefing_window import (
+    BRIEFING_ALERT_JOB,
+    BRIEFING_JOB,
+    GENERATE_CUTOFF,
+    BriefingWindow,
+    load_briefing_window,
+)
 from mycoach.sources.base import ImportResult
-from mycoach.sources.garmin.source import GarminSource
+from mycoach.sources.garmin.source import DeviceUpload, GarminSource
 from mycoach.sources.merger import merge_garmin_hevy
 
 logger = logging.getLogger(__name__)
@@ -44,20 +55,6 @@ logger = logging.getLogger(__name__)
 USER_ID = 1  # Single-user MVP
 
 DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-
-# The fields that make a briefing about recovery rather than about nothing —
-# sleep, HRV, and Body Battery. A snapshot can pass the empty-day guard (it has
-# *some* content, e.g. resting HR and steps) while carrying none of these, which
-# is exactly the 13/08 symptom the spec opens with. Named here so the intent
-# behind the check below is legible, not a bare inline tuple.
-_RECOVERY_FIELDS = (
-    "sleep_duration_minutes",
-    "sleep_score",
-    "hrv_status",
-    "hrv_7day_avg",
-    "hrv_status_text",
-    "body_battery_morning",
-)
 
 
 def _run_async(coro):  # type: ignore[no-untyped-def]
@@ -245,16 +242,58 @@ async def _garmin_sync(days: int | None = None) -> ImportResult:
             result.activities_created,
             merge_result.merged,
         )
+        # ``fetch_and_import`` already worked out which endpoints failed and
+        # which days came back empty; logging only the three counts threw that
+        # away, and re-deriving it later cost four ad-hoc probe scripts. A
+        # counts-only line cannot distinguish "Garmin returned nulls" from
+        # "every call raised", and those need opposite responses.
+        for error in result.errors or []:
+            logger.warning("Scheduler: Garmin sync detail — %s", error)
         return result
 
 
-def job_daily_briefing() -> None:
-    """Generate the daily coaching briefing."""
-    logger.info("Scheduler: generating daily briefing")
-    _run_recorded_job("daily_briefing", _daily_briefing())
+def job_daily_briefing_poll() -> None:
+    """One tick of the daily-briefing retry loop.
+
+    Registered on a 15-minute cron across the whole window rather than as a
+    single 09:30 entry. Whether a given tick does anything is decided from
+    ``job_runs``, not from the trigger, so a container restart mid-window
+    neither duplicates a briefing nor loses the day — see
+    ``mycoach.scheduler.briefing_window``.
+    """
+    _run_async(_daily_briefing_poll())
 
 
-async def _daily_briefing() -> None:
+async def _daily_briefing_poll() -> None:
+    """Decide from today's runs whether to generate, alert, both, or neither.
+
+    Deliberately *not* wrapped in ``_record_run``: a tick that decides to do
+    nothing must leave no trace, or the 15-minute poll would write ~44 rows a
+    day into the very table the decision is read from, and every attempt count
+    it derives would be nonsense. Only real work — an attempt, or an alert —
+    records a run.
+    """
+    async with async_session() as session:
+        window = await load_briefing_window(session)
+
+    if window.should_generate:
+        logger.info(
+            "Scheduler: daily briefing attempt %d for %s",
+            window.attempts + 1,
+            window.day,
+        )
+        await _record_run(BRIEFING_JOB, _daily_briefing(window.day))
+        # Re-read rather than reason forward from the old state: the attempt
+        # just made is exactly the one that decides whether an alert is due,
+        # and its outcome is only knowable from the row it wrote.
+        async with async_session() as session:
+            window = await load_briefing_window(session)
+
+    if window.should_alert:
+        await _record_run(BRIEFING_ALERT_JOB, _briefing_alert(window))
+
+
+async def _daily_briefing(today: date | None = None) -> None:
     """Sync fresh Garmin data, then generate the briefing from it.
 
     The sync is part of the job rather than a separate cron entry because the
@@ -262,44 +301,114 @@ async def _daily_briefing() -> None:
     without last night's sleep, and the standalone 06:00 sync runs before
     Garmin has finalised it. Encoding that in the job beats spacing two crons
     and hoping.
+
+    ``today`` is the local day the poll decided to brief on, so every attempt
+    in a window targets the same day even if one straddles midnight. Today only
+    — an older day is never backfilled.
+
+    The empty-data guard is *not* here. It lives in
+    ``CoachingEngine.generate_daily_briefing`` so this job, the retry loop and
+    the dashboard button all get the same answer; this body only decorates the
+    resulting skip with what the sync saw.
     """
-    today = date.today()
+    today = today or date.today()
 
     # A sync failure is not a reason to withhold a briefing — yesterday's data
-    # may well be enough, and the failure is logged either way. Only a
-    # confirmed absence of today's data below stops the run.
-    empty_days: list[date] = []
+    # may well be enough, and the failure is recorded either way. Only the
+    # engine's guard, below, decides whether there is anything to brief on.
+    sync_errors: list[str] = []
     try:
-        sync_result = await _garmin_sync()
-        empty_days = list(sync_result.empty_health_days)
-    except Exception as e:  # logged, and the briefing may still be viable
-        logger.error("Scheduler: pre-briefing Garmin sync failed — %s", e)
-
-    if today in empty_days:
-        raise PipelineSkip(
-            f"Garmin returned no usable health data for {today} — skipping the "
-            f"briefing rather than inferring recovery from nothing"
+        # A narrow lookback, unlike the standalone 06:00 sync's seven days. This
+        # runs on every tick of a 15-minute poll, and a seven-day window is
+        # ~80 Garmin requests — ~1,400 a day on a day with no data, against an
+        # account the whole loop depends on staying unthrottled. Recovering
+        # older late uploads is the 06:00 sync's job; this one only needs the
+        # day it is briefing about and the night either side of it.
+        sync_result = await _garmin_sync(
+            days=get_settings().scheduler_briefing_sync_lookback_days
         )
+        sync_errors = list(sync_result.errors or [])
+    except Exception as e:  # recorded, and the briefing may still be viable
+        logger.error("Scheduler: pre-briefing Garmin sync failed — %s", e)
+        sync_errors = [f"Garmin sync raised: {e}"]
 
     engine = CoachingEngine()
     async with async_session() as session:
-        # A day can carry some content (e.g. resting HR, steps) yet none of the
-        # fields the briefing exists to speak to. That is not "no data" — the
-        # skip above is deliberately narrow — but it must not pass silently.
-        today_health = await get_today_health(session, USER_ID, today)
-        if not any(field in today_health for field in _RECOVERY_FIELDS):
-            logger.warning(
-                "Scheduler: generating daily briefing for %s without any recovery "
-                "data (no sleep, HRV, or Body Battery)",
-                today,
-            )
+        try:
+            insight = await engine.generate_daily_briefing(session, USER_ID, today=today)
+        except InsufficientHealthData as e:
+            # The sync detail is folded into the skip reason here and nowhere
+            # else. It is the answer to the question this whole retry loop is
+            # for — "did Garmin return nulls, or did every call raise?" — and
+            # ``job_runs.skip_reason`` is the only place a reader will look for
+            # it days later.
+            raise InsufficientHealthData(_with_sync_detail(str(e), sync_errors)) from e
 
-        insight = await engine.generate_daily_briefing(session, USER_ID)
         logger.info("Scheduler: daily briefing generated")
 
         if await _get_user_email_pref("email_daily_briefing"):
             content = json.loads(insight.content)
             _deliver(partial(send_daily_briefing, content), "daily briefing")
+
+
+def _with_sync_detail(reason: str, sync_errors: list[str]) -> str:
+    """Append what the pre-briefing sync reported to a skip reason.
+
+    Truncated, because ``skip_reason`` is read by a human in a table: a
+    seven-day lookback can produce one line per day per failing endpoint, and
+    the first few say everything the rest repeat.
+    """
+    if not sync_errors:
+        return reason
+    shown = sync_errors[:3]
+    suffix = "; ".join(shown)
+    if len(sync_errors) > len(shown):
+        suffix += f"; (+{len(sync_errors) - len(shown)} more)"
+    return f"{reason} | sync reported: {suffix}"
+
+
+async def _briefing_alert(window: BriefingWindow) -> None:
+    """Email the user that this morning has produced no briefing.
+
+    Runs under ``_record_run`` as ``daily_briefing_alert``, which is what makes
+    "at most one email per day" true without any state of its own: the next
+    poll sees the recorded run and stands down.
+
+    The last-upload lookup is best-effort and deliberately skipped when the
+    fault is ours — asking Garmin when the watch last synced is neither
+    relevant to a validation error nor worth the round trip.
+    """
+    if not await _get_user_email_pref("email_daily_briefing"):
+        raise PipelineSkip(
+            "daily briefing email is switched off — no alert to send"
+        )
+
+    upload = None if window.is_broken else await _last_device_upload()
+
+    _deliver(
+        partial(
+            send_briefing_unavailable,
+            day=window.day.strftime("%A, %B %-d"),
+            failures=window.failed_attempts,
+            is_broken=window.is_broken,
+            can_still_retry=(
+                window.now.time() < GENERATE_CUTOFF and not window.budget_exhausted
+            ),
+            detail=window.last_detail,
+            last_upload=upload.uploaded_at if upload else None,
+            device_name=upload.device_name if upload else None,
+        ),
+        "briefing unavailable",
+    )
+
+
+async def _last_device_upload() -> DeviceUpload | None:
+    """Ask Garmin when the watch last uploaded, or None if it won't say."""
+    source = GarminSource()
+    if not await source.authenticate():
+        logger.warning("Scheduler: Garmin auth failed during briefing alert")
+        return None
+    return source.get_last_device_upload()
 
 
 

--- a/src/mycoach/scheduler/scheduler.py
+++ b/src/mycoach/scheduler/scheduler.py
@@ -2,9 +2,12 @@
 
 The scheduler runs five jobs as part of the daily coaching pipeline:
 1. Garmin sync (default 6:00 AM) — fetch health + activity data
-2. Daily briefing (default 9:30 AM) — syncs Garmin first, then generates the
-   briefing from the fresh data. The standalone 6:00 AM sync runs before Garmin
-   has finalised the night's sleep, so the briefing cannot rely on it.
+2. Daily briefing (default from 9:30 AM) — a poll, not a single shot. Every
+   15 minutes it syncs Garmin and, if the data has arrived, generates the
+   briefing; it stops generating at 14:00 and stops watching at 20:00. The
+   standalone 6:00 AM sync runs before Garmin has finalised the night's sleep,
+   so the briefing cannot rely on it, and the watch's own upload can land hours
+   later still — hence a window rather than a moment.
 3. Post-workout analysis (default 7:00 AM) — analyze new activities after sync
 4. Weekly plan (default Sunday 6:00 PM) — generate next week's training plan
 5. Weekly recap (default Monday 7:00 AM) — recap the previous week
@@ -18,8 +21,13 @@ import logging
 from apscheduler.schedulers.background import BackgroundScheduler  # type: ignore[import-untyped]
 
 from mycoach.config import Settings
+from mycoach.scheduler.briefing_window import (
+    EVALUATE_CUTOFF,
+    GENERATE_CUTOFF,
+    POLL_INTERVAL_MINUTES,
+)
 from mycoach.scheduler.jobs import (
-    job_daily_briefing,
+    job_daily_briefing_poll,
     job_garmin_sync,
     job_post_workout_analysis,
     job_weekly_plan,
@@ -45,6 +53,19 @@ def create_scheduler(settings: Settings) -> BackgroundScheduler:
 
     Jobs are not started — call scheduler.start() to begin execution.
     """
+    # Checked before a single job is added, because both failure modes without
+    # it are worse than a startup error. An hour past the evaluation cutoff
+    # makes APScheduler's own range validation raise something opaque about
+    # minimums and maximums; an hour between the two cutoffs builds a perfectly
+    # valid trigger that then silently never generates anything, which is the
+    # class of silent failure this whole change exists to remove.
+    if settings.scheduler_briefing_hour >= GENERATE_CUTOFF.hour:
+        raise ValueError(
+            f"MYCOACH_SCHEDULER_BRIEFING_HOUR={settings.scheduler_briefing_hour} is "
+            f"at or after the {GENERATE_CUTOFF:%H:%M} briefing generation cutoff, so "
+            f"no briefing could ever be generated. Set it earlier."
+        )
+
     scheduler = BackgroundScheduler(timezone=settings.scheduler_timezone)
 
     # 1. Garmin sync — daily (fetches health + activities, then auto-merges)
@@ -58,14 +79,28 @@ def create_scheduler(settings: Settings) -> BackgroundScheduler:
         replace_existing=True,
     )
 
-    # 2. Daily briefing — daily; syncs Garmin itself first
+    # 2. Daily briefing — polled across a window; syncs Garmin itself each tick.
+    #
+    # The trigger is deliberately dumber than the behaviour: it fires on every
+    # quarter hour from the briefing hour to the evaluation cutoff, and each
+    # tick asks ``briefing_window`` whether there is anything to do. Putting the
+    # window's real bounds (opens at the configured minute, stops generating at
+    # 14:00, one alert per day) in the trigger would split the rules across a
+    # cron expression and a decision function, and only one of those two can be
+    # read off ``job_runs`` after the fact.
+    #
+    # A short grace time with coalescing, rather than the hour the once-a-day
+    # jobs use: a poll missed while the container was down should be replaced by
+    # the next one, not replayed as a burst of stale ticks.
     scheduler.add_job(
-        job_daily_briefing,
+        job_daily_briefing_poll,
         "cron",
         id="daily_briefing",
-        hour=settings.scheduler_briefing_hour,
-        minute=settings.scheduler_briefing_minute,
-        misfire_grace_time=3600,
+        hour=f"{settings.scheduler_briefing_hour}-{EVALUATE_CUTOFF.hour}",
+        minute=f"*/{POLL_INTERVAL_MINUTES}",
+        misfire_grace_time=300,
+        coalesce=True,
+        max_instances=1,
         replace_existing=True,
     )
 
@@ -107,12 +142,14 @@ def create_scheduler(settings: Settings) -> BackgroundScheduler:
     )
 
     logger.info(
-        "Scheduler configured: sync=%02d:%02d, briefing=%02d:%02d, "
+        "Scheduler configured: sync=%02d:%02d, briefing polls %02d:%02d-%02d:00/%dm, "
         "post_workout=%02d:%02d, plan=%s@%02d:%02d, recap=%s@%02d:%02d, tz=%s",
         settings.scheduler_sync_hour,
         settings.scheduler_sync_minute,
         settings.scheduler_briefing_hour,
         settings.scheduler_briefing_minute,
+        EVALUATE_CUTOFF.hour,
+        POLL_INTERVAL_MINUTES,
         settings.scheduler_post_workout_hour,
         settings.scheduler_post_workout_minute,
         plan_day,

--- a/src/mycoach/sources/garmin/client.py
+++ b/src/mycoach/sources/garmin/client.py
@@ -89,6 +89,16 @@ class GarminClient:
         """Get SpO2 data for a day."""
         return self.api.get_spo2_data(day.isoformat())  # type: ignore[no-any-return]
 
+    def get_device_last_used(self) -> dict[str, Any]:
+        """Get the last-used device, including when it last uploaded to Garmin.
+
+        This is the only endpoint that distinguishes "the watch has nothing to
+        say about today" from "the watch has not spoken to Garmin's servers
+        since Tuesday" — the two look identical in a day's health response, and
+        only the second is something the user can act on.
+        """
+        return self.api.get_device_last_used()  # type: ignore[no-any-return]
+
     def get_activities_by_date(self, start: date, end: date) -> list[dict[str, Any]]:
         """Get activities for a date range."""
         return self.api.get_activities_by_date(  # type: ignore[no-any-return]

--- a/src/mycoach/sources/garmin/source.py
+++ b/src/mycoach/sources/garmin/source.py
@@ -1,7 +1,8 @@
 """Garmin DataSource implementation — orchestrates auth, fetch, and import."""
 
 import logging
-from datetime import date, datetime, timedelta
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 from sqlalchemy import select
@@ -20,6 +21,16 @@ from mycoach.sources.garmin.mappers import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DeviceUpload:
+    """When the user's watch last reached Garmin's servers, and which watch."""
+
+    uploaded_at: datetime
+    """UTC, timezone-aware."""
+
+    device_name: str | None
 
 
 class GarminSource(DataSource):
@@ -105,6 +116,36 @@ class GarminSource(DataSource):
         if errors:
             result.errors = errors
         return result
+
+    def get_last_device_upload(self) -> DeviceUpload | None:
+        """When the watch last uploaded to Garmin, or None if that is unknowable.
+
+        A day of nulls does not say whether the user simply had nothing to
+        record or whether the watch stopped syncing days ago; this does. It is
+        what turns an alert from "no briefing today" into "your watch hasn't
+        uploaded since Aug 19 at 05:20", which is the difference between a
+        message the user can act on and one they can only be annoyed by.
+
+        Returns None rather than raising: this only ever decorates an alert
+        that is already being sent, and losing the decoration must not lose
+        the alert.
+        """
+        try:
+            device = self._client.get_device_last_used()
+        except Exception as e:  # noqa: BLE001 - the alert matters more than the detail
+            logger.warning("Garmin last-used-device lookup failed: %s", e)
+            return None
+
+        if not isinstance(device, dict):
+            return None
+        raw = device.get("lastUsedDeviceUploadTime")
+        if not isinstance(raw, int | float):
+            return None
+        # Garmin reports this as epoch milliseconds.
+        return DeviceUpload(
+            uploaded_at=datetime.fromtimestamp(raw / 1000, tz=UTC),
+            device_name=device.get("lastUsedDeviceName") or None,
+        )
 
     def _fetch_health_for_day(
         self, user_id: int, day: date

--- a/src/mycoach/templates/dashboard.html
+++ b/src/mycoach/templates/dashboard.html
@@ -56,12 +56,25 @@
         <div class="h-[5px] w-[200px] bg-white/[0.12] rounded mt-5"></div>
     </div>
     <div class="flex items-center gap-5 mt-4">
-        <p class="text-[17px] leading-relaxed text-zinc-500 max-w-[600px]">No daily briefing generated yet. Sync your Garmin data, then generate today's read.</p>
+        <p class="text-[17px] leading-relaxed text-zinc-500 max-w-[600px]">
+            {%- if briefing_banner -%}
+            {{ briefing_banner }}
+            {%- else -%}
+            No daily briefing generated yet. Sync your Garmin data, then generate today's read.
+            {%- endif -%}
+        </p>
+        {# Disabled rather than hidden: the button's absence would read as a bug,
+           its refusal reads as an explanation. The endpoint enforces the same
+           rule with a 422 regardless of what the page renders. #}
         <button id="briefing-btn" onclick="generateBriefing()"
+            {% if briefing_blocked_reason %}disabled title="{{ briefing_blocked_reason }}"{% endif %}
             class="ml-auto shrink-0 font-semibold text-[13px] text-ink bg-accent hover:bg-accent-soft transition-colors px-5 py-2.5 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed">
             <span id="briefing-label">Generate briefing</span>
         </button>
     </div>
+    {% if briefing_blocked_reason %}
+    <p class="mt-3 text-sm text-zinc-500 max-w-[600px]">Can't generate: {{ briefing_blocked_reason }}</p>
+    {% endif %}
     <div id="briefing-status"></div>
     {% endif %}
 

--- a/tests/test_coaching/test_api.py
+++ b/tests/test_coaching/test_api.py
@@ -6,6 +6,7 @@ from datetime import date, timedelta
 from httpx import AsyncClient
 
 from mycoach.models.coaching import CoachingInsight
+from mycoach.models.health import DailyHealthSnapshot
 from mycoach.models.user import User
 from tests.conftest import test_session
 
@@ -103,6 +104,39 @@ class TestGetTodayBriefing:
 
 class TestGenerateBriefing:
     async def test_409_when_already_exists(self, client: AsyncClient) -> None:
+        await _seed_user_and_briefing()
+        resp = await client.post("/api/coaching/today/generate")
+        assert resp.status_code == 409
+
+    async def test_422_when_today_has_no_recovery_data(self, client: AsyncClient) -> None:
+        """The manual path used to bypass the guard the scheduler enforced.
+
+        422 rather than 409: nothing already exists, the request simply cannot
+        be satisfied from today's data.
+        """
+        await _seed_user()
+        resp = await client.post("/api/coaching/today/generate")
+        assert resp.status_code == 422
+
+    async def test_the_422_names_what_is_missing(self, client: AsyncClient) -> None:
+        """The dashboard shows this text verbatim, so it has to be a sentence."""
+        user_id = await _seed_user()
+        async with test_session() as session:
+            session.add(
+                DailyHealthSnapshot(
+                    user_id=user_id, snapshot_date=date.today(), resting_hr=58
+                )
+            )
+            await session.commit()
+
+        resp = await client.post("/api/coaching/today/generate")
+        assert resp.status_code == 422
+        assert "sleep, HRV, or Body Battery" in resp.json()["detail"]
+
+    async def test_an_existing_briefing_still_beats_the_data_guard(
+        self, client: AsyncClient
+    ) -> None:
+        """A day with a briefing but no snapshot is a duplicate, not a data problem."""
         await _seed_user_and_briefing()
         resp = await client.post("/api/coaching/today/generate")
         assert resp.status_code == 409

--- a/tests/test_coaching/test_engine.py
+++ b/tests/test_coaching/test_engine.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy import select
 
 from mycoach.coaching.engine import CoachingEngine
-from mycoach.coaching.exceptions import PipelineSkip
+from mycoach.coaching.exceptions import InsufficientHealthData, PipelineSkip
 from mycoach.coaching.llm_client import LLMResponse
 from mycoach.models.health import DailyHealthSnapshot
 from mycoach.models.prompt_log import PromptLog
@@ -44,6 +44,24 @@ def _mock_llm_client(content: str = VALID_LLM_RESPONSE) -> MagicMock:
     client.daily_model = "claude-sonnet-4-5-20250929"
     client.weekly_model = "claude-opus-4-6"
     return client
+
+
+async def _add_recovery_snapshot(session: object, user_id: int, day: date) -> None:
+    """Give the day enough recovery data to clear the engine's empty-data guard.
+
+    Every daily-briefing path now refuses a day with no sleep, HRV, or Body
+    Battery, so a test about anything *else* still has to supply one.
+    """
+    session.add(  # type: ignore[union-attr]
+        DailyHealthSnapshot(
+            user_id=user_id,
+            snapshot_date=day,
+            resting_hr=55,
+            sleep_score=82,
+            sleep_duration_minutes=450,
+        )
+    )
+    await session.commit()  # type: ignore[union-attr]
 
 
 async def _create_user(session: object) -> int:
@@ -86,6 +104,7 @@ class TestGenerateDailyBriefing:
         async with test_session() as session:
             user_id = await _create_user(session)
             today = date(2024, 6, 10)
+            await _add_recovery_snapshot(session, user_id, today)
 
             mock_llm = _mock_llm_client()
             engine = CoachingEngine(llm_client=mock_llm)
@@ -103,6 +122,7 @@ class TestGenerateDailyBriefing:
         async with test_session() as session:
             user_id = await _create_user(session)
             today = date(2024, 6, 10)
+            await _add_recovery_snapshot(session, user_id, today)
 
             mock_llm = _mock_llm_client()
             engine = CoachingEngine(llm_client=mock_llm)
@@ -111,10 +131,94 @@ class TestGenerateDailyBriefing:
             with pytest.raises(PipelineSkip, match="already exists"):
                 await engine.generate_daily_briefing(session, user_id, today)
 
+    async def test_refuses_a_day_with_no_health_snapshot_at_all(self) -> None:
+        """The guard lives here so cron, retry loop and button cannot drift.
+
+        For six days the dashboard invited the user to press a button that
+        bypassed this rule entirely and would have briefed on nothing.
+        """
+        async with test_session() as session:
+            user_id = await _create_user(session)
+            mock_llm = _mock_llm_client()
+            engine = CoachingEngine(llm_client=mock_llm)
+
+            with pytest.raises(InsufficientHealthData, match="no Garmin health snapshot"):
+                await engine.generate_daily_briefing(session, user_id, date(2024, 6, 10))
+
+            mock_llm.call.assert_not_called()
+
+    async def test_refuses_a_day_carrying_no_recovery_data(self) -> None:
+        """Resting HR and steps are content, but they are not recovery.
+
+        Garmin answers a day it has nothing for with a well-formed document of
+        nulls; a snapshot can survive that and still hold nothing worth
+        coaching from.
+        """
+        async with test_session() as session:
+            user_id = await _create_user(session)
+            today = date(2024, 6, 10)
+            session.add(
+                DailyHealthSnapshot(
+                    user_id=user_id, snapshot_date=today, resting_hr=58, steps=10234
+                )
+            )
+            await session.commit()
+
+            mock_llm = _mock_llm_client()
+            engine = CoachingEngine(llm_client=mock_llm)
+
+            with pytest.raises(InsufficientHealthData, match="no sleep, HRV, or Body Battery"):
+                await engine.generate_daily_briefing(session, user_id, today)
+
+            mock_llm.call.assert_not_called()
+
+    async def test_the_guard_is_a_skip_not_a_failure(self) -> None:
+        """Withholding a briefing from an empty day is correct, not a fault.
+
+        The retry loop reads this straight off ``job_runs``: a skip retries
+        freely, a failure burns the budget.
+        """
+        assert issubclass(InsufficientHealthData, PipelineSkip)
+
+    async def test_force_overrides_the_guard(self) -> None:
+        """The one documented escape hatch, unchanged."""
+        async with test_session() as session:
+            user_id = await _create_user(session)
+            today = date(2024, 6, 10)
+            session.add(
+                DailyHealthSnapshot(user_id=user_id, snapshot_date=today, resting_hr=58)
+            )
+            await session.commit()
+
+            engine = CoachingEngine(llm_client=_mock_llm_client())
+            insight = await engine.generate_daily_briefing(
+                session, user_id, today, force=True
+            )
+
+        assert insight.insight_type == "daily_briefing"
+
+    async def test_any_one_recovery_field_is_enough(self) -> None:
+        """Body Battery alone is a thin day, but it is a day worth speaking to."""
+        async with test_session() as session:
+            user_id = await _create_user(session)
+            today = date(2024, 6, 10)
+            session.add(
+                DailyHealthSnapshot(
+                    user_id=user_id, snapshot_date=today, body_battery_morning=64
+                )
+            )
+            await session.commit()
+
+            engine = CoachingEngine(llm_client=_mock_llm_client())
+            insight = await engine.generate_daily_briefing(session, user_id, today)
+
+        assert insight.insight_type == "daily_briefing"
+
     async def test_llm_failure_raises_and_logs(self) -> None:
         async with test_session() as session:
             user_id = await _create_user(session)
             today = date(2024, 6, 10)
+            await _add_recovery_snapshot(session, user_id, today)
 
             mock_llm = _mock_llm_client()
             mock_llm.call.side_effect = Exception("API timeout")
@@ -133,6 +237,7 @@ class TestGenerateDailyBriefing:
         async with test_session() as session:
             user_id = await _create_user(session)
             today = date(2024, 6, 10)
+            await _add_recovery_snapshot(session, user_id, today)
 
             mock_llm = _mock_llm_client()
             # First call returns bad JSON, second call returns valid

--- a/tests/test_email/test_sender.py
+++ b/tests/test_email/test_sender.py
@@ -1,5 +1,6 @@
 """Tests for the email sender module."""
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,7 @@ from mycoach.email.sender import (
     _format_key_metrics,
     _format_session_details,
     _render_template,
+    send_briefing_unavailable,
     send_daily_briefing,
     send_email,
     send_no_availability,
@@ -462,3 +464,147 @@ def test_send_weekly_recap_wires_dashboard_url(mock_send: MagicMock) -> None:
     send_weekly_recap(content={"week_summary": "Solid"}, week_start="2025-02-24", settings=settings)
     html = mock_send.call_args[0][2]
     assert "https://coach.example.com/dashboard" in html
+
+
+# --- Briefing-unavailable alert ---
+#
+# The whole point of this email is that it names something the reader can act
+# on, and that it names the *right* thing: a "check your Bluetooth" message for
+# what was actually a validation error inside our own pipeline is worse than no
+# email at all.
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_briefing_alert_names_the_real_gap(mock_send: MagicMock) -> None:
+    settings = _make_settings(timezone="Europe/London")
+    result = send_briefing_unavailable(
+        day="Tuesday, August 25",
+        failures=0,
+        is_broken=False,
+        can_still_retry=True,
+        last_upload=datetime(2026, 8, 19, 4, 20, tzinfo=UTC),
+        device_name="Forerunner 255 Music",
+        settings=settings,
+    )
+    assert result is True
+    html = mock_send.call_args[0][2]
+    assert "hasn&#39;t uploaded to Garmin since Aug 19 at 05:20" in html
+    assert "Bluetooth" in html
+    assert "Forerunner 255 Music" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_briefing_alert_renders_the_upload_time_in_the_users_timezone(
+    mock_send: MagicMock,
+) -> None:
+    """05:20 BST, not 04:20 UTC — the reader compares it against their morning."""
+    settings = _make_settings(timezone="Europe/London")
+    send_briefing_unavailable(
+        day="Tuesday, August 25",
+        failures=0,
+        is_broken=False,
+        can_still_retry=True,
+        last_upload=datetime(2026, 8, 19, 4, 20, tzinfo=UTC),
+        settings=settings,
+    )
+    assert "Aug 19 at 05:20" in mock_send.call_args[0][2]
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_briefing_alert_counts_errors_not_skips(mock_send: MagicMock) -> None:
+    """Four data-less skips plus one real error is one error, not five.
+
+    Reporting five would send the reader hunting for a fault that isn't there.
+    """
+    send_briefing_unavailable(
+        day="Tuesday, August 25",
+        failures=1,
+        is_broken=True,
+        can_still_retry=True,
+        settings=_make_settings(),
+    )
+    html = mock_send.call_args[0][2]
+    assert "1 attempt hit an error" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_briefing_alert_quotes_no_count_when_the_watch_is_at_fault(
+    mock_send: MagicMock,
+) -> None:
+    """How many times we asked is our business; when the watch last synced is theirs."""
+    send_briefing_unavailable(
+        day="Tuesday, August 25",
+        failures=0,
+        is_broken=False,
+        can_still_retry=True,
+        settings=_make_settings(),
+    )
+    html = mock_send.call_args[0][2]
+    assert "0 attempts" not in html
+    assert "hit an error" not in html
+    assert "Bluetooth" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_briefing_alert_does_not_blame_the_watch_for_our_own_fault(
+    mock_send: MagicMock,
+) -> None:
+    settings = _make_settings()
+    send_briefing_unavailable(
+        day="Tuesday, August 25",
+        failures=3,
+        is_broken=True,
+        can_still_retry=False,
+        detail="hrv_status: Input should be a valid number",
+        settings=settings,
+    )
+    html = mock_send.call_args[0][2]
+    assert "Bluetooth" not in html
+    assert "fault on our side" in html
+    assert "hrv_status" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_briefing_alert_says_more_attempts_are_coming(mock_send: MagicMock) -> None:
+    settings = _make_settings()
+    send_briefing_unavailable(
+        day="Tuesday, August 25",
+        failures=0,
+        is_broken=False,
+        can_still_retry=True,
+        settings=settings,
+    )
+    html = mock_send.call_args[0][2]
+    assert "every 15 minutes" in html
+    assert "14:00" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_briefing_alert_says_when_the_day_is_over(mock_send: MagicMock) -> None:
+    settings = _make_settings()
+    send_briefing_unavailable(
+        day="Tuesday, August 25",
+        failures=0,
+        is_broken=False,
+        can_still_retry=False,
+        settings=settings,
+    )
+    html = mock_send.call_args[0][2]
+    assert "cutoff has passed" in html
+
+
+@patch("mycoach.email.sender.send_email", return_value=True)
+def test_briefing_alert_works_without_an_upload_time(mock_send: MagicMock) -> None:
+    """Garmin may not say; the alert still has to go."""
+    settings = _make_settings()
+    result = send_briefing_unavailable(
+        day="Tuesday, August 25",
+        failures=0,
+        is_broken=False,
+        can_still_retry=True,
+        settings=settings,
+    )
+    assert result is True
+    html = mock_send.call_args[0][2]
+    assert "Last upload" not in html
+    assert "Bluetooth" in html

--- a/tests/test_pages/test_dashboard.py
+++ b/tests/test_pages/test_dashboard.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import date, datetime, timedelta
+from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -10,6 +11,7 @@ from httpx import AsyncClient
 from mycoach.config import get_settings
 from mycoach.models.coaching import CoachingInsight
 from mycoach.models.health import DailyHealthSnapshot
+from mycoach.models.job_run import JobRun
 from mycoach.models.plan import PlannedSession, WeeklyPlan
 from mycoach.models.user import User
 from tests.conftest import test_session
@@ -357,3 +359,72 @@ async def test_dashboard_sync_stamp_advances_on_no_op_resync(client: AsyncClient
 
     resp = await client.get("/")
     assert resp.text != first_sync_text
+
+
+async def test_dashboard_reports_the_retry_loops_own_state(client: AsyncClient) -> None:
+    """The old text blamed a sync that had in fact succeeded.
+
+    ``dashboard.html`` is server-rendered Jinja and ``job_runs`` is an ordinary
+    table, so the true state is one query away — no new API endpoint. The
+    window is forced open from midnight so the assertion does not depend on
+    what time the suite happens to run.
+    """
+    await _seed_user()
+    async with test_session() as session:
+        for i in range(4):
+            session.add(
+                JobRun(
+                    job_name="daily_briefing",
+                    started_at=datetime.utcnow() - timedelta(minutes=15 * (i + 1)),
+                    duration_ms=800,
+                    status="skipped",
+                    skip_reason="no usable Garmin health data",
+                )
+            )
+        await session.commit()
+
+    always_open = get_settings().model_copy(
+        update={"scheduler_briefing_hour": 0, "scheduler_briefing_minute": 0}
+    )
+    with patch(
+        "mycoach.scheduler.briefing_window.get_settings", return_value=always_open
+    ):
+        resp = await client.get("/")
+
+    assert resp.status_code == 200
+    assert "Waiting on Garmin" in resp.text or "never returned" in resp.text
+    assert "No daily briefing generated yet" not in resp.text
+
+
+async def test_dashboard_disables_the_button_it_knows_would_be_refused(
+    client: AsyncClient,
+) -> None:
+    """Six days of inviting a click that would have briefed on nothing."""
+    await _seed_user()
+    async with test_session() as session:
+        session.add(
+            DailyHealthSnapshot(user_id=1, snapshot_date=date.today(), resting_hr=58)
+        )
+        await session.commit()
+
+    resp = await client.get("/")
+    assert resp.status_code == 200
+    assert "Can&#39;t generate:" in resp.text or "Can't generate:" in resp.text
+    assert "sleep, HRV, or Body Battery" in resp.text
+
+
+async def test_dashboard_leaves_the_button_alone_on_a_usable_day(
+    client: AsyncClient,
+) -> None:
+    await _seed_user()
+    async with test_session() as session:
+        session.add(
+            DailyHealthSnapshot(
+                user_id=1, snapshot_date=date.today(), resting_hr=58, sleep_score=82
+            )
+        )
+        await session.commit()
+
+    resp = await client.get("/")
+    assert resp.status_code == 200
+    assert "Can't generate" not in resp.text and "Can&#39;t generate" not in resp.text

--- a/tests/test_scheduler/test_briefing_window.py
+++ b/tests/test_scheduler/test_briefing_window.py
@@ -1,0 +1,482 @@
+"""Tests for the daily-briefing retry window.
+
+Two halves: the decision logic, which is a pure function of a
+``BriefingWindow``'s fields and is tested by constructing them directly, and
+``load_briefing_window``, which is tested against real ``job_runs`` rows because
+the whole point of the design is that the state is nowhere else.
+"""
+
+from datetime import date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from mycoach.config import Settings, get_settings
+from mycoach.models.coaching import CoachingInsight
+from mycoach.models.job_run import JobRun
+from mycoach.scheduler.briefing_window import (
+    ALERT_AFTER_ATTEMPTS,
+    BRIEFING_ALERT_JOB,
+    BRIEFING_JOB,
+    MAX_FAILED_ATTEMPTS,
+    BriefingWindow,
+    load_briefing_window,
+)
+from tests.conftest import test_session
+
+TZ = ZoneInfo("Europe/London")
+DAY = date(2026, 8, 25)
+OPENS_AT = time(9, 30)
+
+
+def _window(
+    at: time = time(10, 0),
+    succeeded: bool = False,
+    skipped: int = 0,
+    failed: int = 0,
+    last_status: str | None = None,
+    last_detail: str | None = None,
+    alerted: bool = False,
+    alert_failures: int = 0,
+) -> BriefingWindow:
+    if last_status is None and (skipped or failed):
+        last_status = "failed" if failed else "skipped"
+    return BriefingWindow(
+        now=datetime.combine(DAY, at, tzinfo=TZ),
+        day=DAY,
+        opens_at=OPENS_AT,
+        succeeded=succeeded,
+        skipped_attempts=skipped,
+        failed_attempts=failed,
+        last_status=last_status,
+        last_detail=last_detail,
+        alerted=alerted,
+        alert_failures=alert_failures,
+    )
+
+
+class TestShouldGenerate:
+    def test_generates_at_the_moment_the_window_opens(self) -> None:
+        assert _window(at=OPENS_AT).should_generate is True
+
+    def test_does_not_generate_before_the_window_opens(self) -> None:
+        """The cron fires on every quarter hour; only the state gates the start."""
+        assert _window(at=time(9, 15)).should_generate is False
+
+    def test_does_not_generate_once_a_briefing_has_succeeded(self) -> None:
+        """The whole reason no in-memory state is kept: this is read off job_runs."""
+        assert _window(at=time(11, 0), succeeded=True, skipped=3).should_generate is False
+
+    def test_keeps_generating_through_repeated_skips(self) -> None:
+        """A skip means the data has not arrived yet, which is what retrying is for."""
+        assert _window(at=time(13, 45), skipped=17).should_generate is True
+
+    def test_stops_generating_at_the_cutoff(self) -> None:
+        """A briefing about this morning's recovery delivered at 18:00 is wrong, not late."""
+        assert _window(at=time(14, 0), skipped=18).should_generate is False
+
+    def test_stops_generating_once_the_failure_budget_is_spent(self) -> None:
+        """Re-running a broken pipeline every 15 minutes only reproduces the stack trace."""
+        assert _window(at=time(10, 30), failed=MAX_FAILED_ATTEMPTS).should_generate is False
+
+    def test_still_generating_one_failure_short_of_the_budget(self) -> None:
+        assert (
+            _window(at=time(10, 30), failed=MAX_FAILED_ATTEMPTS - 1).should_generate is True
+        )
+
+    def test_skips_do_not_count_against_the_failure_budget(self) -> None:
+        """The two outcomes are distinguished durably; the loop must honour that."""
+        assert _window(at=time(12, 0), skipped=10, failed=1).should_generate is True
+
+
+class TestShouldAlert:
+    def test_silent_through_the_grace_period(self) -> None:
+        """The one-hour grace kills essentially every false alarm in the history."""
+        assert _window(at=time(10, 15), skipped=ALERT_AFTER_ATTEMPTS - 1).should_alert is False
+
+    def test_alerts_once_the_grace_period_has_passed(self) -> None:
+        assert _window(at=time(10, 30), skipped=ALERT_AFTER_ATTEMPTS).should_alert is True
+
+    def test_never_alerts_twice_in_a_day(self) -> None:
+        assert (
+            _window(at=time(12, 0), skipped=10, alerted=True).should_alert is False
+        )
+
+    def test_does_not_alert_when_the_briefing_landed(self) -> None:
+        assert (
+            _window(at=time(11, 0), succeeded=True, skipped=6).should_alert is False
+        )
+
+    def test_alerts_after_the_generate_cutoff(self) -> None:
+        """Past 14:00 nothing more will be generated — which is exactly worth saying."""
+        assert _window(at=time(15, 0), skipped=20).should_alert is True
+
+    def test_alerts_when_the_failure_budget_is_spent(self) -> None:
+        """A dead pipeline is the case the user most needs to hear about.
+
+        The budget stops generation at three attempts — one short of the grace
+        period — so keying only off the attempt count would leave exactly this
+        day silent from 09:30 to midnight.
+        """
+        assert (
+            _window(at=time(10, 15), failed=MAX_FAILED_ATTEMPTS).should_generate is False
+        )
+        assert _window(at=time(10, 15), failed=MAX_FAILED_ATTEMPTS).should_alert is True
+
+    def test_alerts_past_the_cutoff_even_if_nothing_was_ever_attempted(self) -> None:
+        """A container down all morning is silence too, and silence is the bug."""
+        assert _window(at=time(14, 15)).should_alert is True
+
+    def test_does_not_alert_before_the_cutoff_with_nothing_attempted(self) -> None:
+        """Between ticks, zero attempts is just the gap — not news."""
+        assert _window(at=time(9, 45)).should_alert is False
+
+    def test_gives_up_on_an_email_backend_that_keeps_refusing(self) -> None:
+        """A misconfigured backend must not become forty rejected sends a day."""
+        assert (
+            _window(at=time(12, 0), skipped=10, alert_failures=MAX_FAILED_ATTEMPTS)
+            .should_alert
+            is False
+        )
+
+    def test_stops_evaluating_at_the_evening_cutoff(self) -> None:
+        assert _window(at=time(20, 0), skipped=30).should_alert is False
+
+
+class TestIsBroken:
+    def test_a_skip_is_not_broken(self) -> None:
+        """Absent data is the user's watch, not our pipeline."""
+        assert _window(skipped=5).is_broken is False
+
+    def test_a_failure_is_broken(self) -> None:
+        """A 'check your Bluetooth' email for a Pydantic error is worse than none."""
+        assert _window(failed=1).is_broken is True
+
+    def test_reads_the_latest_attempt_not_the_tally(self) -> None:
+        """A day that failed once at 09:30 and has skipped since is a data problem."""
+        assert _window(skipped=4, failed=1, last_status="skipped").is_broken is False
+
+
+class TestBanner:
+    def test_silent_before_anything_has_been_attempted(self) -> None:
+        assert _window(at=time(9, 30)).banner is None
+
+    def test_silent_once_the_briefing_exists(self) -> None:
+        assert _window(at=time(11, 0), succeeded=True, skipped=4).banner is None
+
+    def test_names_the_wait_rather_than_blaming_the_sync(self) -> None:
+        """The old text told the user to sync while the sync had in fact succeeded."""
+        banner = _window(at=time(10, 30), skipped=4).banner
+        assert banner is not None
+        assert "Waiting on Garmin" in banner
+        assert "09:30" in banner and "14:00" in banner
+
+    def test_says_so_when_the_fault_is_ours(self) -> None:
+        banner = _window(at=time(10, 0), failed=1, last_detail="hrv_status: not a float").banner
+        assert banner is not None
+        assert "error" in banner
+        assert "hrv_status: not a float" in banner
+
+    def test_counts_failures_not_attempts_against_the_budget(self) -> None:
+        """Skips are not errors; "attempt 4 of 3" is a lie about both."""
+        banner = _window(
+            at=time(10, 30), skipped=3, failed=1, last_status="failed"
+        ).banner
+        assert banner is not None
+        assert f"1 of {MAX_FAILED_ATTEMPTS}" in banner
+
+    def test_says_nothing_about_a_window_that_went_by_unattempted(self) -> None:
+        """With no runs recorded there is nothing to report, and a fresh
+        install with no Garmin account reads identically. The email covers the
+        day the container slept through; the page does not guess."""
+        assert _window(at=time(15, 0)).banner is None
+
+    def test_says_retries_have_stopped_once_the_budget_is_spent(self) -> None:
+        banner = _window(at=time(11, 0), failed=MAX_FAILED_ATTEMPTS).banner
+        assert banner is not None
+        assert "retries have stopped" in banner
+
+    def test_reports_the_missed_day_after_the_cutoff(self) -> None:
+        banner = _window(at=time(16, 0), skipped=18).banner
+        assert banner is not None
+        assert "never returned" in banner
+
+
+@pytest.fixture
+def settings() -> Settings:
+    base = get_settings()
+    return base.model_copy(
+        update={
+            "timezone": "Europe/London",
+            "scheduler_timezone": "Europe/London",
+            "scheduler_briefing_hour": 9,
+            "scheduler_briefing_minute": 30,
+        }
+    )
+
+
+def _run(
+    job_name: str, status: str, at: datetime, error: str | None = None,
+    skip_reason: str | None = None,
+) -> JobRun:
+    return JobRun(
+        job_name=job_name,
+        started_at=at,
+        duration_ms=1000,
+        status=status,
+        error=error,
+        skip_reason=skip_reason,
+    )
+
+
+class TestLoadBriefingWindow:
+    """The state is a query, never a variable — that is the hard requirement."""
+
+    async def test_empty_day_has_nothing_attempted(self, settings: Settings) -> None:
+        async with test_session() as session:
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(9, 30), tzinfo=TZ), settings=settings
+            )
+        assert window.attempts == 0
+        assert window.succeeded is False
+        assert window.last_status is None
+
+    async def test_counts_skips_and_failures_separately(self, settings: Settings) -> None:
+        async with test_session() as session:
+            session.add_all(
+                [
+                    _run(BRIEFING_JOB, "skipped", datetime(2026, 8, 25, 8, 30),
+                         skip_reason="no data"),
+                    _run(BRIEFING_JOB, "failed", datetime(2026, 8, 25, 8, 45), error="boom"),
+                    _run(BRIEFING_JOB, "skipped", datetime(2026, 8, 25, 9, 0),
+                         skip_reason="no data"),
+                ]
+            )
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(10, 30), tzinfo=TZ), settings=settings
+            )
+
+        assert window.skipped_attempts == 2
+        assert window.failed_attempts == 1
+        assert window.attempts == 3
+        assert window.last_status == "skipped"
+        assert window.last_detail == "no data"
+
+    async def test_reads_the_error_of_a_failed_last_attempt(self, settings: Settings) -> None:
+        async with test_session() as session:
+            session.add(
+                _run(BRIEFING_JOB, "failed", datetime(2026, 8, 25, 8, 45), error="hrv_status")
+            )
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(10, 30), tzinfo=TZ), settings=settings
+            )
+
+        assert window.last_detail == "hrv_status"
+        assert window.is_broken is True
+
+    async def test_a_success_today_closes_the_window(self, settings: Settings) -> None:
+        async with test_session() as session:
+            session.add_all(
+                [
+                    _run(BRIEFING_JOB, "skipped", datetime(2026, 8, 25, 8, 30)),
+                    _run(BRIEFING_JOB, "success", datetime(2026, 8, 25, 9, 15)),
+                ]
+            )
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(10, 30), tzinfo=TZ), settings=settings
+            )
+
+        assert window.succeeded is True
+        assert window.should_generate is False
+
+    async def test_a_recorded_alert_run_is_the_once_per_day_lock(
+        self, settings: Settings
+    ) -> None:
+        """No 'have I emailed yet' flag exists; the alert's own run row is it."""
+        async with test_session() as session:
+            session.add_all(
+                [_run(BRIEFING_JOB, "skipped", datetime(2026, 8, 25, 8, 30 + i))
+                 for i in range(0, ALERT_AFTER_ATTEMPTS)]
+            )
+            session.add(_run(BRIEFING_ALERT_JOB, "success", datetime(2026, 8, 25, 9, 30)))
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(11, 0), tzinfo=TZ), settings=settings
+            )
+
+        assert window.alerted is True
+        assert window.should_alert is False
+
+    async def test_an_alert_that_failed_to_send_is_retried(
+        self, settings: Settings
+    ) -> None:
+        """Otherwise a rejected send would silence the day it was meant to report."""
+        async with test_session() as session:
+            session.add_all(
+                [_run(BRIEFING_JOB, "skipped", datetime(2026, 8, 25, 8, 30 + i))
+                 for i in range(0, ALERT_AFTER_ATTEMPTS)]
+            )
+            session.add(_run(BRIEFING_ALERT_JOB, "failed", datetime(2026, 8, 25, 9, 30)))
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(11, 0), tzinfo=TZ), settings=settings
+            )
+
+        assert window.alerted is False
+        assert window.alert_failures == 1
+        assert window.should_alert is True
+
+    async def test_a_skipped_alert_settles_the_day(self, settings: Settings) -> None:
+        """Email switched off means there was deliberately nothing to send.
+
+        Retrying that on every tick would write ~40 rows a day into the table
+        the whole decision is read from.
+        """
+        async with test_session() as session:
+            session.add_all(
+                [_run(BRIEFING_JOB, "skipped", datetime(2026, 8, 25, 8, 30 + i))
+                 for i in range(0, ALERT_AFTER_ATTEMPTS)]
+            )
+            session.add(
+                _run(
+                    BRIEFING_ALERT_JOB,
+                    "skipped",
+                    datetime(2026, 8, 25, 9, 30),
+                    skip_reason="daily briefing email is switched off",
+                )
+            )
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(11, 0), tzinfo=TZ), settings=settings
+            )
+
+        assert window.alerted is True
+        assert window.should_alert is False
+
+    async def test_a_manually_generated_briefing_stands_the_loop_down(
+        self, settings: Settings
+    ) -> None:
+        """The button and the loop must not disagree about whether today is done.
+
+        Otherwise a briefing generated by hand at 10:00 would leave the poll
+        re-syncing Garmin and recording a duplicate skip every 15 minutes until
+        the cutoff.
+        """
+        async with test_session() as session:
+            session.add(
+                CoachingInsight(
+                    user_id=1,
+                    insight_date=DAY,
+                    insight_type="daily_briefing",
+                    content='{"readiness_verdict": "moderate"}',
+                )
+            )
+            session.add(_run(BRIEFING_JOB, "skipped", datetime(2026, 8, 25, 8, 30)))
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(10, 30), tzinfo=TZ), settings=settings
+            )
+
+        assert window.succeeded is True
+        assert window.should_generate is False
+        assert window.should_alert is False
+
+    async def test_yesterdays_briefing_does_not_stand_today_down(
+        self, settings: Settings
+    ) -> None:
+        async with test_session() as session:
+            session.add(
+                CoachingInsight(
+                    user_id=1,
+                    insight_date=DAY - timedelta(days=1),
+                    insight_type="daily_briefing",
+                    content="{}",
+                )
+            )
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(9, 30), tzinfo=TZ), settings=settings
+            )
+
+        assert window.succeeded is False
+
+    async def test_another_insight_type_does_not_stand_today_down(
+        self, settings: Settings
+    ) -> None:
+        async with test_session() as session:
+            session.add(
+                CoachingInsight(
+                    user_id=1,
+                    insight_date=DAY,
+                    insight_type="weekly_recap",
+                    content="{}",
+                )
+            )
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(9, 30), tzinfo=TZ), settings=settings
+            )
+
+        assert window.succeeded is False
+
+    async def test_yesterdays_runs_do_not_count(self, settings: Settings) -> None:
+        """Otherwise a bad Monday would suppress Tuesday's briefing entirely."""
+        async with test_session() as session:
+            session.add_all(
+                [
+                    _run(BRIEFING_JOB, "success", datetime(2026, 8, 24, 8, 30)),
+                    _run(BRIEFING_JOB, "failed", datetime(2026, 8, 24, 9, 0)),
+                ]
+            )
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(9, 30), tzinfo=TZ), settings=settings
+            )
+
+        assert window.succeeded is False
+        assert window.attempts == 0
+
+    async def test_other_jobs_runs_do_not_count(self, settings: Settings) -> None:
+        async with test_session() as session:
+            session.add_all(
+                [
+                    _run("garmin_sync", "success", datetime(2026, 8, 25, 8, 30)),
+                    _run("weekly_recap", "failed", datetime(2026, 8, 25, 8, 40)),
+                ]
+            )
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=datetime.combine(DAY, time(10, 30), tzinfo=TZ), settings=settings
+            )
+
+        assert window.attempts == 0
+        assert window.succeeded is False
+
+    async def test_the_local_day_bounds_are_converted_to_utc(self) -> None:
+        """``started_at`` is naive UTC; the day is local. Getting this wrong loses runs.
+
+        In a UTC+11 zone, 09:30 local on the 25th is 22:30 UTC on the *24th* —
+        a run recorded then must still count as today's.
+        """
+        tz = ZoneInfo("Australia/Sydney")
+        settings = get_settings().model_copy(
+            update={"timezone": "Australia/Sydney", "scheduler_timezone": "Australia/Sydney"}
+        )
+        async with test_session() as session:
+            local_930 = datetime.combine(DAY, time(9, 30), tzinfo=tz)
+            session.add(
+                _run(
+                    BRIEFING_JOB,
+                    "skipped",
+                    local_930.astimezone(ZoneInfo("UTC")).replace(tzinfo=None),
+                )
+            )
+            await session.commit()
+            window = await load_briefing_window(
+                session, now=local_930 + timedelta(minutes=15), settings=settings
+            )
+
+        assert window.attempts == 1

--- a/tests/test_scheduler/test_job_runs.py
+++ b/tests/test_scheduler/test_job_runs.py
@@ -128,7 +128,7 @@ async def test_daily_briefing_body_records_run() -> None:
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", test_session),
@@ -153,7 +153,7 @@ async def test_daily_briefing_body_records_skip() -> None:
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", test_session),
@@ -175,7 +175,7 @@ async def test_daily_briefing_body_records_failure() -> None:
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", test_session),
@@ -518,7 +518,7 @@ async def test_records_email_delivered_when_send_succeeds() -> None:
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
@@ -542,7 +542,7 @@ async def test_records_email_not_delivered_when_type_is_disabled() -> None:
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
@@ -563,7 +563,7 @@ async def test_rejected_send_fails_the_run_with_the_cause() -> None:
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
@@ -590,7 +590,7 @@ async def test_rejected_send_records_the_backend_reason() -> None:
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
@@ -619,7 +619,7 @@ async def test_unattempted_send_records_the_configuration_cause() -> None:
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),
@@ -641,7 +641,7 @@ async def test_delivery_appears_in_the_structured_log_line(
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=_briefing_engine()),
         patch("mycoach.scheduler.jobs.async_session", test_session),

--- a/tests/test_scheduler/test_jobs.py
+++ b/tests/test_scheduler/test_jobs.py
@@ -6,14 +6,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from mycoach.coaching.exceptions import NoAvailabilityConfigured, PipelineSkip
+from mycoach.coaching.exceptions import (
+    InsufficientHealthData,
+    NoAvailabilityConfigured,
+    PipelineSkip,
+)
+from mycoach.config import get_settings
 from mycoach.scheduler.jobs import (
+    _briefing_alert,
     _daily_briefing,
+    _daily_briefing_poll,
     _garmin_sync,
     _post_workout_analysis,
+    _record_run,
     _weekly_plan,
     _weekly_recap,
-    job_daily_briefing,
     job_garmin_sync,
     job_weekly_plan,
     job_weekly_recap,
@@ -143,14 +150,10 @@ async def test_daily_briefing_success(mock_session: AsyncMock, mock_engine: Magi
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
-        patch(
-            "mycoach.scheduler.jobs.get_today_health",
-            AsyncMock(return_value={"sleep_score": 80}),
-        ),
     ):
         await _daily_briefing()
 
@@ -165,7 +168,7 @@ async def test_daily_briefing_syncs_before_generating(
 
     async def fake_sync(days: int | None = None) -> MagicMock:
         calls.append("sync")
-        return MagicMock(empty_health_days=[])
+        return MagicMock(empty_health_days=[], errors=None)
 
     async def fake_generate(*args, **kwargs):  # type: ignore[no-untyped-def]
         calls.append("generate")
@@ -178,34 +181,111 @@ async def test_daily_briefing_syncs_before_generating(
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
-        patch(
-            "mycoach.scheduler.jobs.get_today_health",
-            AsyncMock(return_value={"sleep_score": 80}),
-        ),
     ):
         await _daily_briefing()
 
     assert calls == ["sync", "generate"]
 
 
-async def test_daily_briefing_skips_when_today_has_no_health_data(
+async def test_daily_briefing_propagates_the_engine_guard(
     mock_session: AsyncMock, mock_engine: MagicMock
 ) -> None:
-    """No data is a skip with a reason — never a briefing invented from nothing."""
-    today = date.today()
+    """No data is a skip with a reason — never a briefing invented from nothing.
 
-    async def fake_sync(days: int | None = None) -> MagicMock:
-        return MagicMock(empty_health_days=[today])
+    The rule itself lives in the engine now, so what this pins is that the job
+    does not paper over it: an ``InsufficientHealthData`` reaches ``_record_run``
+    intact and is filed as a skip.
+    """
+    mock_engine.generate_daily_briefing = AsyncMock(
+        side_effect=InsufficientHealthData("no sleep, HRV, or Body Battery")
+    )
 
     with (
-        patch("mycoach.scheduler.jobs._garmin_sync", fake_sync),
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
+        ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
-        pytest.raises(PipelineSkip, match="no usable health data"),
+        pytest.raises(InsufficientHealthData, match="no sleep, HRV, or Body Battery"),
     ):
         await _daily_briefing()
 
-    mock_engine.generate_daily_briefing.assert_not_awaited()
+
+async def test_daily_briefing_skip_carries_the_sync_detail(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """The sync already knew why the day was empty; the skip must not drop it.
+
+    Distinguishing "Garmin returned nulls" from "every call raised" cost four
+    ad-hoc probe scripts during the diagnosis. Both facts are computed by
+    ``fetch_and_import``; this is where they become durable.
+    """
+    mock_engine.generate_daily_briefing = AsyncMock(
+        side_effect=InsufficientHealthData("no sleep, HRV, or Body Battery")
+    )
+    sync_result = MagicMock(
+        empty_health_days=[],
+        errors=["Garmin API calls failed for 2026-08-25: get_sleep_data"],
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", AsyncMock(return_value=sync_result)),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        pytest.raises(InsufficientHealthData) as caught,
+    ):
+        await _daily_briefing()
+
+    assert "get_sleep_data" in str(caught.value)
+
+
+async def test_daily_briefing_skip_carries_a_sync_that_raised(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """A sync that blew up outright is detail too, not just a log line."""
+    mock_engine.generate_daily_briefing = AsyncMock(
+        side_effect=InsufficientHealthData("no sleep, HRV, or Body Battery")
+    )
+
+    async def failing_sync(days: int | None = None) -> MagicMock:
+        raise RuntimeError("Garmin authentication failed")
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", failing_sync),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        pytest.raises(InsufficientHealthData) as caught,
+    ):
+        await _daily_briefing()
+
+    assert "Garmin authentication failed" in str(caught.value)
+
+
+async def test_daily_briefing_generates_for_the_day_it_was_given(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """A window that straddles midnight must not silently change days.
+
+    Every attempt in one retry window targets the day the poll decided on.
+    """
+    mock_engine.generate_daily_briefing = AsyncMock(
+        return_value=MagicMock(content='{"readiness_verdict": "moderate"}')
+    )
+    day = date(2026, 8, 25)
+
+    with (
+        patch(
+            "mycoach.scheduler.jobs._garmin_sync",
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
+        ),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _daily_briefing(day)
+
+    assert mock_engine.generate_daily_briefing.await_args.kwargs["today"] == day
 
 
 async def test_daily_briefing_proceeds_when_sync_fails(
@@ -225,10 +305,6 @@ async def test_daily_briefing_proceeds_when_sync_fails(
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
-        patch(
-            "mycoach.scheduler.jobs.get_today_health",
-            AsyncMock(return_value={"sleep_score": 80}),
-        ),
     ):
         await _daily_briefing()
 
@@ -258,10 +334,6 @@ async def test_daily_briefing_sync_failure_logged_at_error_level(
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
-        patch(
-            "mycoach.scheduler.jobs.get_today_health",
-            AsyncMock(return_value={"sleep_score": 80}),
-        ),
         caplog.at_level(logging.INFO),
     ):
         await _daily_briefing()
@@ -270,61 +342,6 @@ async def test_daily_briefing_sync_failure_logged_at_error_level(
         r.levelno == logging.ERROR and "pre-briefing Garmin sync failed" in r.message
         for r in caplog.records
     )
-
-
-async def test_daily_briefing_warns_when_no_recovery_data(
-    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A snapshot with some content but no sleep/HRV/Body Battery must not pass silently.
-
-    The skip guard is deliberately narrow (only a fully empty day skips), so a
-    thin day like this proceeds to generate a briefing — but it must log loudly
-    that it did so without any recovery data.
-    """
-    with (
-        patch(
-            "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
-        ),
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
-        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
-        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
-        patch(
-            "mycoach.scheduler.jobs.get_today_health",
-            AsyncMock(return_value={"resting_hr": 58, "steps": 10234}),
-        ),
-        caplog.at_level(logging.INFO),
-    ):
-        await _daily_briefing()
-
-    assert any(
-        r.levelno == logging.WARNING and "without any recovery data" in r.message
-        for r in caplog.records
-    )
-    mock_engine.generate_daily_briefing.assert_awaited_once()
-
-
-async def test_daily_briefing_no_warning_when_sleep_data_present(
-    mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
-) -> None:
-    """The no-recovery-data warning must not fire when sleep data is present."""
-    with (
-        patch(
-            "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
-        ),
-        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
-        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
-        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
-        patch(
-            "mycoach.scheduler.jobs.get_today_health",
-            AsyncMock(return_value={"resting_hr": 58, "sleep_score": 80}),
-        ),
-        caplog.at_level(logging.INFO),
-    ):
-        await _daily_briefing()
-
-    assert not any("without any recovery data" in r.message for r in caplog.records)
 
 
 async def test_daily_briefing_raises_skip_on_duplicate(
@@ -338,20 +355,16 @@ async def test_daily_briefing_raises_skip_on_duplicate(
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
-        patch(
-            "mycoach.scheduler.jobs.get_today_health",
-            AsyncMock(return_value={"sleep_score": 80}),
-        ),
         pytest.raises(PipelineSkip),
     ):
         await _daily_briefing()
 
 
-def test_daily_briefing_job_logs_skip(
+async def test_daily_briefing_job_logs_skip(
     mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A skip is logged at info level and swallowed by the job wrapper."""
@@ -362,17 +375,15 @@ def test_daily_briefing_job_logs_skip(
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
-        patch(
-            "mycoach.scheduler.jobs.get_today_health",
-            AsyncMock(return_value={"sleep_score": 80}),
-        ),
         caplog.at_level(logging.INFO),
     ):
-        job_daily_briefing()  # must not raise
+        # The poll's own gating is exercised in test_briefing_window.py; here
+        # only the recording wrapper the poll delegates to is under test.
+        await _record_run("daily_briefing", _daily_briefing())
 
     skip_logs = [
         r for r in caplog.records if "daily_briefing skipped" in r.message
@@ -381,7 +392,7 @@ def test_daily_briefing_job_logs_skip(
     assert not any(r.levelno >= logging.ERROR for r in caplog.records)
 
 
-def test_daily_briefing_job_logs_malformed_response_as_failure(
+async def test_daily_briefing_job_logs_malformed_response_as_failure(
     mock_session: AsyncMock, mock_engine: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A malformed stored response is a failure (error), not a routine skip.
@@ -396,18 +407,16 @@ def test_daily_briefing_job_logs_malformed_response_as_failure(
     with (
         patch(
             "mycoach.scheduler.jobs._garmin_sync",
-            AsyncMock(return_value=MagicMock(empty_health_days=[])),
+            AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None)),
         ),
         patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
         patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
         patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
-        patch(
-            "mycoach.scheduler.jobs.get_today_health",
-            AsyncMock(return_value={"sleep_score": 80}),
-        ),
         caplog.at_level(logging.INFO),
     ):
-        job_daily_briefing()  # must not raise
+        # The poll's own gating is exercised in test_briefing_window.py; here
+        # only the recording wrapper the poll delegates to is under test.
+        await _record_run("daily_briefing", _daily_briefing())
 
     assert any(
         r.levelno == logging.ERROR and "daily_briefing failed" in r.message
@@ -840,3 +849,308 @@ async def test_post_workout_analysis_sends_email(
         await _post_workout_analysis()
 
     mock_send.assert_called_once_with({"performance_summary": "Great workout"}, "Morning Swim")
+
+
+class TestDailyBriefingPoll:
+    """The tick that decides whether today's window has anything left to do.
+
+    Each test pins one branch by stubbing ``load_briefing_window``; what the
+    window itself concludes from ``job_runs`` is pinned in
+    ``test_briefing_window.py``.
+    """
+
+    @staticmethod
+    def _window(**kwargs: object) -> MagicMock:
+        window = MagicMock(
+            should_generate=False,
+            should_alert=False,
+            attempts=0,
+            day=date(2026, 8, 25),
+        )
+        window.configure_mock(**kwargs)
+        return window
+
+    async def test_a_quiet_tick_records_nothing(self, mock_session: AsyncMock) -> None:
+        """~44 ticks a day; a row per tick would drown the table it reads from."""
+        recorded = AsyncMock()
+        with (
+            patch(
+                "mycoach.scheduler.jobs.load_briefing_window",
+                AsyncMock(return_value=self._window()),
+            ),
+            patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+            patch("mycoach.scheduler.jobs._record_run", recorded),
+        ):
+            await _daily_briefing_poll()
+
+        recorded.assert_not_awaited()
+
+    async def test_generating_tick_records_a_daily_briefing_run(
+        self, mock_session: AsyncMock
+    ) -> None:
+        recorded = AsyncMock()
+        with (
+            patch(
+                "mycoach.scheduler.jobs.load_briefing_window",
+                AsyncMock(return_value=self._window(should_generate=True)),
+            ),
+            patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+            patch("mycoach.scheduler.jobs._record_run", recorded),
+        ):
+            await _daily_briefing_poll()
+
+        assert [c.args[0] for c in recorded.await_args_list] == ["daily_briefing"]
+
+    async def test_generates_for_the_windows_day(self, mock_session: AsyncMock) -> None:
+        """The poll picks the day, so every attempt in a window targets the same one."""
+        seen: list[date] = []
+
+        async def fake_briefing(day: date | None = None) -> None:
+            seen.append(day)  # type: ignore[arg-type]
+
+        async def run_body(job_name: str, coro) -> None:  # type: ignore[no-untyped-def]
+            await coro
+
+        with (
+            patch(
+                "mycoach.scheduler.jobs.load_briefing_window",
+                AsyncMock(return_value=self._window(should_generate=True)),
+            ),
+            patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+            patch("mycoach.scheduler.jobs._record_run", run_body),
+            patch("mycoach.scheduler.jobs._daily_briefing", fake_briefing),
+        ):
+            await _daily_briefing_poll()
+
+        assert seen == [date(2026, 8, 25)]
+
+    async def test_rereads_the_window_after_an_attempt(
+        self, mock_session: AsyncMock
+    ) -> None:
+        """The attempt just made is the one that decides whether to alert."""
+        before = self._window(should_generate=True, should_alert=True)
+        after = self._window(should_generate=False, should_alert=False)
+        load = AsyncMock(side_effect=[before, after])
+
+        recorded = AsyncMock()
+        with (
+            patch("mycoach.scheduler.jobs.load_briefing_window", load),
+            patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+            patch("mycoach.scheduler.jobs._record_run", recorded),
+        ):
+            await _daily_briefing_poll()
+
+        # The stale `should_alert=True` must not survive an attempt that succeeded.
+        assert [c.args[0] for c in recorded.await_args_list] == ["daily_briefing"]
+
+    async def test_alerts_and_generates_on_the_same_tick(
+        self, mock_session: AsyncMock
+    ) -> None:
+        """Hitting the grace period is no reason to skip that tick's attempt."""
+        still_stuck = self._window(should_generate=True, should_alert=True)
+        load = AsyncMock(side_effect=[still_stuck, still_stuck])
+
+        recorded = AsyncMock()
+        with (
+            patch("mycoach.scheduler.jobs.load_briefing_window", load),
+            patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+            patch("mycoach.scheduler.jobs._record_run", recorded),
+        ):
+            await _daily_briefing_poll()
+
+        assert [c.args[0] for c in recorded.await_args_list] == [
+            "daily_briefing",
+            "daily_briefing_alert",
+        ]
+
+    async def test_alerts_without_generating_past_the_cutoff(
+        self, mock_session: AsyncMock
+    ) -> None:
+        """Between 14:00 and 20:00 the loop no longer tries but still reports."""
+        recorded = AsyncMock()
+        with (
+            patch(
+                "mycoach.scheduler.jobs.load_briefing_window",
+                AsyncMock(return_value=self._window(should_alert=True)),
+            ),
+            patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+            patch("mycoach.scheduler.jobs._record_run", recorded),
+        ):
+            await _daily_briefing_poll()
+
+        assert [c.args[0] for c in recorded.await_args_list] == ["daily_briefing_alert"]
+
+
+class TestBriefingAlert:
+    """What the alert email is told, which is the difference between it helping and not."""
+
+    @staticmethod
+    def _window(is_broken: bool = False, **kwargs: object) -> MagicMock:
+        window = MagicMock(
+            day=date(2026, 8, 25),
+            attempts=4,
+            failed_attempts=0,
+            is_broken=is_broken,
+            budget_exhausted=False,
+            last_detail="no usable Garmin health data",
+            now=datetime(2026, 8, 25, 10, 30),
+        )
+        window.configure_mock(**kwargs)
+        return window
+
+    async def test_names_the_real_gap_from_the_device_upload_time(self) -> None:
+        """'No briefing today' is not actionable; 'your watch hasn't uploaded since' is."""
+        sent = MagicMock(return_value=True)
+        upload = MagicMock(uploaded_at=datetime(2026, 8, 19, 5, 20), device_name="Forerunner 255")
+
+        with (
+            patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+            patch("mycoach.scheduler.jobs._last_device_upload", AsyncMock(return_value=upload)),
+            patch("mycoach.scheduler.jobs.send_briefing_unavailable", sent),
+        ):
+            await _briefing_alert(self._window())
+
+        kwargs = sent.call_args.kwargs
+        assert kwargs["last_upload"] == datetime(2026, 8, 19, 5, 20)
+        assert kwargs["device_name"] == "Forerunner 255"
+        assert kwargs["is_broken"] is False
+
+    async def test_does_not_blame_the_watch_for_our_own_failure(self) -> None:
+        """A 'check your Bluetooth' email for a Pydantic error is worse than none."""
+        sent = MagicMock(return_value=True)
+        lookup = AsyncMock()
+
+        with (
+            patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+            patch("mycoach.scheduler.jobs._last_device_upload", lookup),
+            patch("mycoach.scheduler.jobs.send_briefing_unavailable", sent),
+        ):
+            await _briefing_alert(self._window(is_broken=True))
+
+        lookup.assert_not_awaited()
+        assert sent.call_args.kwargs["is_broken"] is True
+
+    async def test_still_alerts_when_garmin_will_not_say_when_it_last_synced(self) -> None:
+        """Losing the decoration must not lose the alert."""
+        sent = MagicMock(return_value=True)
+
+        with (
+            patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+            patch("mycoach.scheduler.jobs._last_device_upload", AsyncMock(return_value=None)),
+            patch("mycoach.scheduler.jobs.send_briefing_unavailable", sent),
+        ):
+            await _briefing_alert(self._window())
+
+        assert sent.call_args.kwargs["last_upload"] is None
+
+    async def test_reports_whether_more_attempts_are_coming(self) -> None:
+        sent = MagicMock(return_value=True)
+
+        with (
+            patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=True)),
+            patch("mycoach.scheduler.jobs._last_device_upload", AsyncMock(return_value=None)),
+            patch("mycoach.scheduler.jobs.send_briefing_unavailable", sent),
+        ):
+            await _briefing_alert(self._window(now=datetime(2026, 8, 25, 15, 0)))
+
+        assert sent.call_args.kwargs["can_still_retry"] is False
+
+    async def test_skips_when_the_user_has_briefing_email_switched_off(self) -> None:
+        """Recorded as a skip, not a success — a skip does not lock out tomorrow."""
+        sent = MagicMock(return_value=True)
+
+        with (
+            patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+            patch("mycoach.scheduler.jobs.send_briefing_unavailable", sent),
+            pytest.raises(PipelineSkip, match="switched off"),
+        ):
+            await _briefing_alert(self._window())
+
+        sent.assert_not_called()
+
+
+async def test_garmin_sync_logs_the_failure_detail_it_already_computed(
+    mock_session: AsyncMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``_safe_call`` collects every failed call and ``fetch_and_import`` folds them in.
+
+    The job then logged three counts and dropped ``errors`` on the floor —
+    nothing read it. Re-deriving "Garmin returned nulls" vs "every call raised"
+    afterwards cost four ad-hoc probe scripts.
+    """
+    mock_source = MagicMock()
+    mock_source.authenticate = AsyncMock(return_value=True)
+    mock_result = MagicMock(
+        health_snapshots_created=0,
+        activities_created=0,
+        errors=[
+            "Garmin API calls failed for 2026-08-25: get_sleep_data, get_hrv_data",
+            "1 day(s) synced with no usable Garmin health data: 2026-08-25",
+        ],
+    )
+    mock_source.fetch_and_import = AsyncMock(return_value=mock_result)
+
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch(
+            "mycoach.scheduler.jobs.merge_garmin_hevy",
+            AsyncMock(return_value=MagicMock(merged=0)),
+        ),
+        caplog.at_level(logging.INFO),
+    ):
+        await _garmin_sync()
+
+    logged = " ".join(r.message for r in caplog.records if r.levelno == logging.WARNING)
+    assert "get_sleep_data" in logged
+    assert "no usable Garmin health data" in logged
+
+
+async def test_garmin_sync_stays_quiet_when_nothing_failed(
+    mock_session: AsyncMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A clean sync must not manufacture warnings out of an empty error list."""
+    mock_source = MagicMock()
+    mock_source.authenticate = AsyncMock(return_value=True)
+    mock_source.fetch_and_import = AsyncMock(
+        return_value=MagicMock(health_snapshots_created=7, activities_created=1, errors=None)
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs.GarminSource", return_value=mock_source),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch(
+            "mycoach.scheduler.jobs.merge_garmin_hevy",
+            AsyncMock(return_value=MagicMock(merged=0)),
+        ),
+        caplog.at_level(logging.INFO),
+    ):
+        await _garmin_sync()
+
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+async def test_briefing_sync_uses_the_narrow_per_tick_lookback(
+    mock_session: AsyncMock, mock_engine: MagicMock
+) -> None:
+    """A 7-day window is ~80 Garmin requests; forty ticks a day would be ~1,400.
+
+    Throttling the account the whole retry loop depends on would defeat the
+    point. Recovering older late uploads stays the 06:00 sync's job.
+    """
+    sync = AsyncMock(return_value=MagicMock(empty_health_days=[], errors=None))
+    mock_engine.generate_daily_briefing = AsyncMock(
+        return_value=MagicMock(content='{"readiness_verdict": "moderate"}')
+    )
+
+    with (
+        patch("mycoach.scheduler.jobs._garmin_sync", sync),
+        patch("mycoach.scheduler.jobs.CoachingEngine", return_value=mock_engine),
+        patch("mycoach.scheduler.jobs.async_session", return_value=mock_session),
+        patch("mycoach.scheduler.jobs._get_user_email_pref", AsyncMock(return_value=False)),
+    ):
+        await _daily_briefing()
+
+    days = sync.await_args.kwargs["days"]
+    assert days == get_settings().scheduler_briefing_sync_lookback_days
+    assert days < get_settings().scheduler_sync_lookback_days

--- a/tests/test_scheduler/test_scheduler.py
+++ b/tests/test_scheduler/test_scheduler.py
@@ -91,3 +91,50 @@ def test_scheduler_not_started() -> None:
     settings = Settings()
     scheduler = create_scheduler(settings)
     assert not scheduler.running
+
+
+def test_daily_briefing_is_registered_as_a_poll_not_a_single_shot() -> None:
+    """One 09:30 attempt loses roughly one briefing in five to upload timing alone."""
+    settings = Settings(scheduler_briefing_hour=9, scheduler_briefing_minute=30)
+    job = create_scheduler(settings).get_job("daily_briefing")
+
+    assert job is not None
+    trigger = str(job.trigger)
+    assert "*/15" in trigger
+    assert "9-20" in trigger
+
+
+def test_daily_briefing_poll_does_not_replay_stale_ticks() -> None:
+    """A poll missed while the container was down is replaced, not queued up."""
+    job = create_scheduler(Settings()).get_job("daily_briefing")
+
+    assert job is not None
+    assert job.coalesce is True
+    assert job.max_instances == 1
+    assert job.misfire_grace_time == 300
+
+
+def test_rejects_a_briefing_hour_that_could_never_generate() -> None:
+    """Between the two cutoffs the trigger is valid but never generates anything.
+
+    A silent no-op is the exact class of failure the retry window exists to
+    remove, so it fails loudly at startup instead — naming the setting.
+    """
+    import pytest
+
+    with pytest.raises(ValueError, match="MYCOACH_SCHEDULER_BRIEFING_HOUR=14"):
+        create_scheduler(Settings(scheduler_briefing_hour=14))
+
+
+def test_rejects_a_briefing_hour_past_the_evaluation_cutoff() -> None:
+    """APScheduler's own error here is an opaque note about ranges."""
+    import pytest
+
+    with pytest.raises(ValueError, match="could ever be generated"):
+        create_scheduler(Settings(scheduler_briefing_hour=21))
+
+
+def test_a_late_but_workable_briefing_hour_still_builds_a_trigger() -> None:
+    job = create_scheduler(Settings(scheduler_briefing_hour=13)).get_job("daily_briefing")
+    assert job is not None
+    assert "13-20" in str(job.trigger)

--- a/tests/test_sources/test_garmin.py
+++ b/tests/test_sources/test_garmin.py
@@ -1,7 +1,7 @@
 """Tests for Garmin source: mappers, source orchestration, and sync endpoint."""
 
 import logging
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -845,3 +845,40 @@ class TestSnapshotHasData:
         )
         assert snapshot.steps == 0
         assert snapshot_has_data(snapshot) is True
+
+
+class TestLastDeviceUpload:
+    """When the watch last reached Garmin — the one fact an alert can act on."""
+
+    def test_reads_the_upload_time_as_epoch_milliseconds(self) -> None:
+        client = MagicMock()
+        client.get_device_last_used.return_value = {
+            "lastUsedDeviceUploadTime": 1755577764000,
+            "lastUsedDeviceName": "Forerunner 255 Music",
+        }
+        upload = GarminSource(client=client).get_last_device_upload()
+
+        assert upload is not None
+        assert upload.uploaded_at == datetime(2025, 8, 19, 4, 29, 24, tzinfo=UTC)
+        assert upload.device_name == "Forerunner 255 Music"
+
+    def test_returns_none_when_garmin_raises(self) -> None:
+        """This only decorates an alert already going out; losing it must not lose that."""
+        client = MagicMock()
+        client.get_device_last_used.side_effect = RuntimeError("401")
+        assert GarminSource(client=client).get_last_device_upload() is None
+
+    def test_returns_none_when_the_field_is_absent(self) -> None:
+        client = MagicMock()
+        client.get_device_last_used.return_value = {"lastUsedDeviceName": "Forerunner"}
+        assert GarminSource(client=client).get_last_device_upload() is None
+
+    def test_tolerates_a_device_with_no_name(self) -> None:
+        client = MagicMock()
+        client.get_device_last_used.return_value = {
+            "lastUsedDeviceUploadTime": 1755577764000
+        }
+        upload = GarminSource(client=client).get_last_device_upload()
+
+        assert upload is not None
+        assert upload.device_name is None


### PR DESCRIPTION
Closes #62

## Why

The briefing failed to generate on 6 of the last 9 days. The skip guard was correct every time — Garmin genuinely had nothing when the job ran, because the watch uploads over Bluetooth only and had backlogged six days, dumping them at 09:29 on 08-25. What was broken is that **a skip was invisible, and a skip was final**: the dashboard told the user to sync while reporting a sync that had in fact succeeded, and no alert of any kind was raised.

The second-order finding matters as much as the outage: same-day uploads land anywhere between 05:09 and 17:44, so two of nine landed *after* the 09:30 window. Even a healthy watch loses roughly one briefing in five to timing alone.

## What changed

### Retry window + failure budget

`daily_briefing` becomes a `*/15` cron across `briefing_hour`–20:00. It generates on the first attempt with usable data, stops generating at **14:00** (a briefing about this morning's recovery delivered at 18:00 is wrong, not late), and keeps evaluating to **20:00** so a day that never got data is still reported. Today's data only; an older day is never backfilled.

Skips retry freely. Real failures get a budget of three — re-running a broken pipeline every quarter hour only reproduces the stack trace. The two outcomes were already distinguished durably by `_record_run`, so the loop reads them straight off `job_runs`.

### State is derived, never held

New `src/mycoach/scheduler/briefing_window.py`. `BriefingWindow` is a frozen dataclass whose `should_generate` / `should_alert` / `banner` are pure functions of its fields; `load_briefing_window` builds it from `job_runs`.

This is the hard requirement from the issue, not a preference: the scheduler has no jobstore and rebuilds its jobs on every boot, and the container restarted mid-incident. In-memory retry state would have meant either a duplicate briefing or a silently dropped window. Even "have we emailed yet?" is the alert's own `job_runs` row rather than a flag.

A quiet tick records nothing, so a 15-minute poll doesn't write ~44 rows a day into the table the decision is read from.

One addition beyond the issue: `succeeded` also reads the insight itself, so a briefing generated by hand at 10:00 stands the loop down instead of leaving it re-syncing Garmin until the cutoff.

### Alerting

After four attempts (~10:30), one email per day, naming the real gap from `lastUsedDeviceUploadTime` — *"your watch hasn't uploaded to Garmin since Aug 19 at 05:20"* — via a new `GarminSource.get_last_device_upload()`. The wording turns on whether the fault was the watch or our own pipeline: a "check your Bluetooth" email for what was actually a validation error is worse than no email.

The dashboard banner renders the same state continuously from `job_runs`. `dashboard.html` is server-rendered Jinja, so `api/pages/dashboard.py` reads the table directly — no new endpoint.

### Unified empty-data guard

The guard moves from `_daily_briefing` into `CoachingEngine.generate_daily_briefing` as `InsufficientHealthData(PipelineSkip)`, so cron, retry loop and button cannot drift. The manual path bypassed it entirely — for six days the dashboard invited a click that would have briefed on a snapshot carrying nothing but a display name. That path now answers **422** naming what is missing, the button renders disabled with the same reason, and `force=true` stays the one escape hatch.

### Sync failure detail

`_safe_call` collects every failed Garmin call and `fetch_and_import` folds them into `ImportResult.errors`; the job logged three counts and dropped them. Distinguishing "Garmin returned nulls" from "every call raised" afterwards cost four ad-hoc probe scripts. They are now logged, and folded into `job_runs.skip_reason` where a reader will look for them days later.

## Review

`/code-review high` found five issues, all real, all fixed in this branch:

| Finding | Fix |
|---|---|
| 3 failures halted generation at 3 attempts, one short of the 4-attempt alert threshold — no briefing **and** no email, all day | `should_alert` also fires on a spent budget or past the 14:00 cutoff |
| `briefing_hour=21` made APScheduler raise an opaque range error at startup; `14`–`20` built a valid trigger that could never generate | `create_scheduler` rejects both, naming the setting |
| "fault on our side" headline used total attempts, so 3 skips + 1 error read as 4 errors | takes `failures`; data-absent branches quote no count at all |
| Banner rendered "attempt 4 of 3" | uses `failed_attempts` |
| 7-day lookback ran on every tick — ~1,400 Garmin requests on a data-less day, against the account the loop depends on | new `scheduler_briefing_sync_lookback_days: int = 2`; the 06:00 sync keeps the wide window |

## Verification

711 tests pass (up from 626 on `main`). `mypy src/` and `ruff check src/ tests/` both sit at their pre-existing baselines — 3 and 9 findings respectively, all in files this branch doesn't touch.

## Notes for review

- Two tests in `test_jobs.py` were deleted rather than adapted: they pinned the old behaviour where a thin day *generated* a briefing with a warning. Under the unified guard a thin day is a skip, pinned by new engine tests instead.
- The window constants (14:00, 20:00, 15 min, 4 attempts, 3 failures) are module constants, not settings. The issue didn't ask for them to be configurable and fewer knobs seemed right — easy to promote if you disagree.
- No migration: `job_runs` is unchanged.

## Explicit non-goal, restated

This does not recover a day where the watch never uploads at all. On those days the new behaviour is an honest 10:30 email instead of silence. That is the intended outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)