### PR TITLE
Split the two HRV fields the daily briefing keeps confusing

### DIFF
--- a/src/mycoach/coaching/prompt_builder.py
+++ b/src/mycoach/coaching/prompt_builder.py
@@ -102,7 +102,7 @@ def _format_health(snapshot: dict[str, Any]) -> str:
         "resting_hr": "Resting Heart Rate",
         "avg_hr": "Avg HR",
         "max_hr": "Max HR (all day)",
-        "hrv_status": "HRV",
+        "hrv_status": "HRV last night avg (ms)",
         "hrv_7day_avg": "HRV 7-day avg",
         "sleep_duration_minutes": "Sleep duration (min)",
         "sleep_score": "Sleep score",
@@ -990,7 +990,7 @@ def _format_health_trends_averaged(averaged: dict[str, Any]) -> str:
     metric_labels = {
         "resting_hr": "Avg Resting HR",
         "avg_hr": "Avg HR",
-        "hrv_status": "Avg HRV",
+        "hrv_status": "Avg HRV (ms)",
         "sleep_duration_minutes": "Avg Sleep (min)",
         "sleep_score": "Avg Sleep Score",
         "avg_stress": "Avg Stress",

--- a/src/mycoach/coaching/response_parser.py
+++ b/src/mycoach/coaching/response_parser.py
@@ -5,7 +5,7 @@ import logging
 import re
 from typing import Any, TypeVar
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -107,12 +107,72 @@ class CardioPlanResponse(BaseModel):
     weekly_summary: str
 
 
+# The keys the model may put the overnight HRV number under: the current field
+# name and the pre-rename one, which older stored briefings still carry.
+_HRV_NUMERIC_KEYS = ("hrv_last_night_avg", "hrv_status")
+
+
 class DailyBriefingKeyMetrics(BaseModel):
+    """The briefing's headline numbers.
+
+    HRV arrives from Garmin's ``hrvSummary`` as two different things — a number
+    (``lastNightAvg``) and a word (``status``: "BALANCED") — so this model keeps
+    them in two fields whose names say which is which. The old name for the
+    number, ``hrv_status``, read like it wanted the word, and the model
+    periodically obliged and lost the whole briefing to a validation error.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
     body_battery: int | None = None
-    hrv_status: float | None = None
+    hrv_last_night_avg: float | None = Field(
+        default=None,
+        validation_alias=AliasChoices(*_HRV_NUMERIC_KEYS),
+    )
+    hrv_status_text: str | None = None
     sleep_score: int | None = None
     training_readiness: int | None = None
     resting_hr: int | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _route_status_word_out_of_the_number(cls, data: Any) -> Any:
+        """Move a non-numeric HRV value into the text field instead of failing.
+
+        A briefing that names the HRV state but not its value is worth far more
+        than no briefing at all, and this is the one field the model is known to
+        confuse. An explicit ``hrv_status_text`` wins over the routed word.
+        """
+        if not isinstance(data, dict):
+            return data
+        for key in _HRV_NUMERIC_KEYS:
+            value = data.get(key)
+            if not isinstance(value, str):
+                continue
+            text = value.strip()
+            try:
+                float(text)
+            except ValueError:
+                pass
+            else:
+                continue  # a plain numeric string; pydantic coerces it itself
+            data = {**data, key: None}
+            if not text:
+                continue
+            number = re.fullmatch(r"([-+]?\d*\.?\d+)\s*[a-zA-Z/%]*", text)
+            if number:
+                # "82 ms" and friends: a number wearing a unit, not a status word.
+                data[key] = float(number.group(1))
+                continue
+            logger.warning(
+                "LLM returned %r for the numeric %s; routing it to hrv_status_text",
+                value,
+                key,
+            )
+            data.setdefault("hrv_status_text", None)
+            if data["hrv_status_text"] is None:
+                data["hrv_status_text"] = text
+        return data
 
 
 class DailyBriefingResponse(BaseModel):

--- a/src/mycoach/email/sender.py
+++ b/src/mycoach/email/sender.py
@@ -48,7 +48,11 @@ def _render_template(template_name: str, context: dict) -> str:  # type: ignore[
 # emails should show them. Keys absent or None are skipped.
 _KEY_METRICS_DISPLAY: dict[str, tuple[str, str]] = {
     "body_battery": ("Body Battery", ""),
-    "hrv_status": ("HRV Status", ""),
+    "hrv_last_night_avg": ("Avg HRV", "ms"),
+    # Briefings stored before the hrv_status rename keep the number under the
+    # old key; both never appear together, so they can share a label.
+    "hrv_status": ("Avg HRV", "ms"),
+    "hrv_status_text": ("HRV Status", ""),
     "sleep_score": ("Sleep Score", ""),
     "training_readiness": ("Training Readiness", ""),
     "resting_hr": ("Resting HR", "bpm"),

--- a/src/mycoach/prompts/v1/daily_briefing.txt
+++ b/src/mycoach/prompts/v1/daily_briefing.txt
@@ -22,7 +22,8 @@ Respond with a JSON object matching this exact schema:
   "sleep_recommendation": "Recommended bedtime and sleep hygiene tips for tonight",
   "key_metrics": {{
     "body_battery": <number or null>,
-    "hrv_status": <number or null>,
+    "hrv_last_night_avg": <last night's average HRV in ms, a number, or null>,
+    "hrv_status_text": <the HRV status word as a string, e.g. "BALANCED", or null>,
     "sleep_score": <number or null>,
     "training_readiness": <number or null>,
     "resting_hr": <number or null>

--- a/src/mycoach/prompts/v2/daily_briefing.txt
+++ b/src/mycoach/prompts/v2/daily_briefing.txt
@@ -22,7 +22,8 @@ Respond with a JSON object matching this exact schema:
   "sleep_recommendation": "Recommended bedtime and sleep hygiene tips for tonight",
   "key_metrics": {{
     "body_battery": <number or null>,
-    "hrv_status": <number or null>,
+    "hrv_last_night_avg": <last night's average HRV in ms, a number, or null>,
+    "hrv_status_text": <the HRV status word as a string, e.g. "BALANCED", or null>,
     "sleep_score": <number or null>,
     "training_readiness": <number or null>,
     "resting_hr": <number or null>

--- a/tests/test_coaching/test_prompt_builder.py
+++ b/tests/test_coaching/test_prompt_builder.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from mycoach.coaching.prompt_builder import (
     _format_activities,
     _format_activity_detail,
@@ -245,6 +247,21 @@ class TestBuildDailyBriefingPrompt:
         assert "Sleep score: 82" in prompt
         assert "Push Day" in prompt
         assert "readiness_verdict" in prompt
+
+    @pytest.mark.parametrize("version", ["v1", "v2"])
+    def test_hrv_output_fields_are_unambiguous(self, version: str) -> None:
+        """The response schema must not ask for a number in a field named `hrv_status`,
+        which is what makes the model answer 'BALANCED' and lose the briefing."""
+        prompt = build_daily_briefing_prompt(
+            health_today={"hrv_status": 82.0, "hrv_status_text": "BALANCED"},
+            health_trends=[],
+            recent_activities=[],
+            version=version,
+        )
+        schema = prompt.split("key_metrics", 1)[1]
+        assert "hrv_last_night_avg" in schema
+        assert "hrv_status_text" in schema
+        assert '"hrv_status"' not in schema
 
     def test_no_data(self) -> None:
         prompt = build_daily_briefing_prompt(

--- a/tests/test_coaching/test_response_parser.py
+++ b/tests/test_coaching/test_response_parser.py
@@ -38,7 +38,8 @@ VALID_BRIEFING = """{
   "sleep_recommendation": "Aim for 10:30 PM bedtime.",
   "key_metrics": {
     "body_battery": 80,
-    "hrv_status": 45.0,
+    "hrv_last_night_avg": 45.0,
+    "hrv_status_text": "BALANCED",
     "sleep_score": 82,
     "training_readiness": 75,
     "resting_hr": 55
@@ -51,7 +52,8 @@ class TestParseResponse:
         result = parse_response(VALID_BRIEFING, DailyBriefingResponse)
         assert result.readiness_verdict == "go_hard"
         assert result.key_metrics.body_battery == 80
-        assert result.key_metrics.hrv_status == 45.0
+        assert result.key_metrics.hrv_last_night_avg == 45.0
+        assert result.key_metrics.hrv_status_text == "BALANCED"
 
     def test_json_in_code_block(self) -> None:
         text = f"```json\n{VALID_BRIEFING}\n```"
@@ -75,7 +77,51 @@ class TestParseResponse:
 
     def test_null_key_metrics(self) -> None:
         data = json.loads(VALID_BRIEFING)
-        data["key_metrics"] = {"body_battery": None, "hrv_status": None}
+        data["key_metrics"] = {"body_battery": None, "hrv_last_night_avg": None}
         result = parse_response(json.dumps(data), DailyBriefingResponse)
         assert result.key_metrics.body_battery is None
         assert result.key_metrics.sleep_score is None
+
+
+class TestBriefingHrvFields:
+    """The LLM confuses Garmin's two HRV fields: a number (lastNightAvg) and a
+    word (status). Neither confusion may cost us the whole briefing.
+    """
+
+    def _parse_metrics(self, **key_metrics: object) -> DailyBriefingResponse:
+        data = json.loads(VALID_BRIEFING)
+        data["key_metrics"] = key_metrics
+        return parse_response(json.dumps(data), DailyBriefingResponse)
+
+    def test_status_word_in_numeric_field_routes_to_text(self) -> None:
+        result = self._parse_metrics(hrv_last_night_avg="BALANCED")
+        assert result.key_metrics.hrv_last_night_avg is None
+        assert result.key_metrics.hrv_status_text == "BALANCED"
+
+    def test_status_word_under_legacy_name_routes_to_text(self) -> None:
+        result = self._parse_metrics(hrv_status="BALANCED")
+        assert result.key_metrics.hrv_last_night_avg is None
+        assert result.key_metrics.hrv_status_text == "BALANCED"
+
+    def test_legacy_numeric_field_name_still_accepted(self) -> None:
+        result = self._parse_metrics(hrv_status=82)
+        assert result.key_metrics.hrv_last_night_avg == 82.0
+
+    def test_numeric_string_still_parses_as_a_number(self) -> None:
+        result = self._parse_metrics(hrv_last_night_avg="82.0")
+        assert result.key_metrics.hrv_last_night_avg == 82.0
+        assert result.key_metrics.hrv_status_text is None
+
+    def test_routed_word_does_not_clobber_an_explicit_status_text(self) -> None:
+        result = self._parse_metrics(hrv_last_night_avg="BALANCED", hrv_status_text="UNBALANCED")
+        assert result.key_metrics.hrv_status_text == "UNBALANCED"
+
+    def test_number_with_a_unit_is_still_a_number(self) -> None:
+        result = self._parse_metrics(hrv_last_night_avg="82 ms")
+        assert result.key_metrics.hrv_last_night_avg == 82.0
+        assert result.key_metrics.hrv_status_text is None
+
+    def test_blank_numeric_field_leaves_both_fields_empty(self) -> None:
+        result = self._parse_metrics(hrv_last_night_avg="  ")
+        assert result.key_metrics.hrv_last_night_avg is None
+        assert result.key_metrics.hrv_status_text is None

--- a/tests/test_email/test_sender.py
+++ b/tests/test_email/test_sender.py
@@ -66,7 +66,7 @@ def test_format_key_metrics_maps_labels_and_skips_none() -> None:
     rows = _format_key_metrics(
         {
             "body_battery": 65,
-            "hrv_status": None,
+            "hrv_last_night_avg": None,
             "sleep_score": 78,
             "training_readiness": None,
             "resting_hr": 52,
@@ -75,6 +75,18 @@ def test_format_key_metrics_maps_labels_and_skips_none() -> None:
     assert rows == {"Body Battery": "65", "Sleep Score": "78", "Resting HR": "52 bpm"}
     # Display order is the order emails show, so it must survive the mapping.
     assert list(rows) == ["Body Battery", "Sleep Score", "Resting HR"]
+
+
+def test_format_key_metrics_shows_both_hrv_fields() -> None:
+    """The HRV number and the HRV status word are separate rows, separately labelled."""
+    rows = _format_key_metrics({"hrv_last_night_avg": 82.0, "hrv_status_text": "BALANCED"})
+    assert rows == {"Avg HRV": "82.0 ms", "HRV Status": "BALANCED"}
+
+
+def test_format_key_metrics_renders_briefings_stored_before_the_hrv_rename() -> None:
+    """Insights saved under the old `hrv_status` name still render their number."""
+    rows = _format_key_metrics({"hrv_status": 82.0})
+    assert rows == {"Avg HRV": "82.0 ms"}
 
 
 def test_format_session_details_gym_exercises() -> None:
@@ -427,14 +439,17 @@ def test_send_daily_briefing_formats_raw_key_metrics(mock_send: MagicMock) -> No
     """send_daily_briefing formats the raw Pydantic-shaped key_metrics before rendering."""
     settings = _make_settings()
     send_daily_briefing(
-        {"readiness_verdict": "moderate", "key_metrics": {"resting_hr": 52, "hrv_status": None}},
+        {
+            "readiness_verdict": "moderate",
+            "key_metrics": {"resting_hr": 52, "hrv_last_night_avg": None},
+        },
         settings=settings,
     )
     html = mock_send.call_args[0][2]
     assert "Resting HR" in html
     assert "52" in html
     assert "bpm" in html
-    assert "HRV Status" not in html  # None values are skipped
+    assert "Avg HRV" not in html  # None values are skipped
 
 
 @patch("mycoach.email.sender.send_email", return_value=True)


### PR DESCRIPTION
Closes #63.

Garmin's `hrvSummary` carries both a number (`lastNightAvg`) and a word (`status: "BALANCED"`). The briefing response schema asked for the number in a field called `hrv_status`, which reads like it wants the word — and roughly once in ten days the model obliged, failing validation on both the first call and the engine's internal retry, costing the whole briefing.

## What changed

- **`response_parser.py`** — `DailyBriefingKeyMetrics.hrv_status` → `hrv_last_night_avg: float | None`, plus a new `hrv_status_text: str | None`. `hrv_status` stays a validation alias, so insights stored under the old name still load.
- **Tolerant parse** — a `mode="before"` validator routes a non-numeric HRV value into the text field and logs it, rather than failing: a briefing that names the HRV state but not its value beats no briefing at all. `"82 ms"` is still read as `82.0`; a blank string leaves both fields empty; an explicit `hrv_status_text` is never clobbered.
- **Prompts (v1 + v2)** — the response schema now names both fields and says which holds the number and which the word. Input labels in `prompt_builder.py` sharpened to `HRV last night avg (ms)` / `Avg HRV (ms)` so the input side maps cleanly onto the output field.
- **Email** — separate `Avg HRV` (ms) and `HRV Status` rows; the legacy `hrv_status` key still renders.

## Verification

722 tests pass. ruff and mypy clean on every touched file; pre-existing errors elsewhere in the repo are untouched.

## Not done

`DailyHealthSnapshot.hrv_status` (the DB column) keeps its name — the issue scoped the trap to the LLM-facing schema, and renaming the column means a migration plus changes in the dashboard, mappers and health schema. Worth a follow-up if you want the two unmistakable everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)