### PR TITLE
feat(logger): hold a screen wake lock during an active session

### DIFF
--- a/src/mycoach/static/logger/app.js
+++ b/src/mycoach/static/logger/app.js
@@ -221,9 +221,53 @@
             .catch(function () {});
     }
 
+    // ── Screen wake lock ────────────────────────────────────────────
+    /* The screen dimming mid-set is the loudest way this feels worse than a
+       paper notebook. The lock is held for exactly as long as an editable
+       session is on screen — acquired when one is opened, released the moment
+       we return home.
+
+       iOS drops the lock whenever the tab backgrounds and never hands it
+       back on its own, so intent (`wakeWanted`) is tracked separately from
+       the sentinel and re-asserted on `visibilitychange`. Every failure path
+       is silent: no wake lock on an unsupported phone is a worse session,
+       not a broken one, and a toast mid-set is noise. */
+    var wakeSentinel = null;
+    var wakeWanted = false;
+    var wakeRequesting = false;
+
+    function acquireWakeLock() {
+        wakeWanted = true;
+        if (!navigator.wakeLock || wakeSentinel || wakeRequesting) return;
+        // A request while hidden is rejected by the browser; the
+        // visibilitychange handler re-asserts it on the way back.
+        if (document.visibilityState !== "visible") return;
+        wakeRequesting = true;
+        navigator.wakeLock.request("screen").then(function (sentinel) {
+            wakeRequesting = false;
+            // Released while the request was still in flight.
+            if (!wakeWanted) { sentinel.release().catch(function () {}); return; }
+            wakeSentinel = sentinel;
+            sentinel.addEventListener("release", function () {
+                if (wakeSentinel === sentinel) wakeSentinel = null;
+            });
+        }).catch(function () {
+            wakeRequesting = false;
+        });
+    }
+
+    function releaseWakeLock() {
+        wakeWanted = false;
+        if (!wakeSentinel) return;
+        var sentinel = wakeSentinel;
+        wakeSentinel = null;
+        sentinel.release().catch(function () {});
+    }
+
     // ── Rendering: Home ─────────────────────────────────────────────
     function render() {
         state.activeId = null;
+        releaseWakeLock();
         setActionbar(null);
         var view = $("view");
         view.innerHTML = "";
@@ -328,6 +372,8 @@
         getSession(id).then(function (s) {
             if (!s) { render(); return; }
             state.activeId = id;
+            if (s.synced) releaseWakeLock(); // read-only: nothing to keep awake for
+            else acquireWakeLock();
             renderSession(s);
         });
     }
@@ -535,7 +581,10 @@
     document.addEventListener("visibilitychange", function () {
         // Walking back into LAN range and reopening the tab should retry
         // without waiting for the next manual sync press.
-        if (document.visibilityState === "visible") syncNow(false);
+        if (document.visibilityState !== "visible") return;
+        syncNow(false);
+        // iOS silently drops the lock when the tab backgrounds.
+        if (wakeWanted) acquireWakeLock();
     });
 
     getMeta("exercises").then(function (list) { if (list) state.exerciseCache = list; });

--- a/src/mycoach/static/logger/sw.js
+++ b/src/mycoach/static/logger/sw.js
@@ -2,7 +2,7 @@
    with no signal at the gym. Scoped to /logger (see Service-Worker-Allowed
    header set by the /logger/sw.js route). */
 
-const CACHE = "mycoach-logger-v3";
+const CACHE = "mycoach-logger-v4";
 // Only purge this SW's own caches on activate — never the main app's
 // `mycoach-v*` caches, which live on the same origin.
 const CACHE_PREFIX = "mycoach-logger-";


### PR DESCRIPTION
Closes #45. Part of the [Gym logging: own the full loop in `/logger`](https://github.com/ffrt-labs/mycoach/issues/44) map.

## What

The phone dims mid-set today — nothing in `app.js` touches `navigator.wakeLock`. This holds a screen wake lock for exactly as long as an editable session is on screen.

- **Acquire** in `openSession`, gated on `!s.synced` — a synced session is read-only, so there is nothing to keep the screen awake for. `startSession` and `startFromRoutineDay` both funnel through `openSession`, so this is one seam rather than three.
- **Release** at the top of `render()`. Home is the single exit from an active session — Finish, Back and delete all already land there, and the cancel path from #46 will too when it is built. The invariant is "home view ⇒ no lock" rather than a release call per exit.
- **Re-acquire** on `visibilitychange` back to visible, folded into the existing handler alongside `syncNow`. iOS drops the lock whenever the tab backgrounds and never restores it, so intent (`wakeWanted`) is tracked separately from the sentinel and re-asserted on the way back.
- Feature-detected on `navigator.wakeLock`. Every failure path — unsupported iOS, non-secure context, the OS refusing under low battery — is a silent no-op. No toast: a missing wake lock is a worse session, not a broken one.
- An in-flight guard (`wakeRequesting`) keeps two rapid opens from double-requesting.

Also bumps the SW cache to `mycoach-logger-v4`. Shell assets are cache-first with no revalidation, so without the bump the phone keeps serving the old `app.js`.

## Verification — please read before merging

`tests/test_logger_routines.py` and `tests/test_pages` pass (48), but that proves nothing about this change: there is **no JS test infrastructure in this repo**, so the wake lock has no automated coverage. No JS runtime was available in the authoring environment either, so not even a syntax check was run. Diff review is the only assurance behind this.

**The ticket's stated definition of done is a manual check on the actual phone**, and it is the one thing that could not be done here:

> start a session → lock the phone or switch apps for ~30s → return → the screen still does not dim.

That exercises the iOS re-acquire path, which is the part built defensively and unverified. #45 is deliberately still open pending that result.

If it fails on the phone, the likely culprit is the lock being requested while `visibilityState` is still transitioning, and the fix is a `pageshow` listener alongside `visibilitychange`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)