### PR TITLE
Decide and land: test the logger's JS with node:test

### DIFF
--- a/src/mycoach/static/logger/app.css
+++ b/src/mycoach/static/logger/app.css
@@ -292,7 +292,7 @@ body.reordering { user-select: none; -webkit-user-select: none; cursor: grabbing
 
 /* editable set rows — the row is the input, there is no save step */
 .setrow--edit {
-    grid-template-columns: 34px 1fr 1fr 58px 28px;
+    grid-template-columns: 34px 1fr 1fr 28px;
     padding: 5px 0;
     /* clears the fixed action bar when a focused row is scrolled into view */
     scroll-margin: 96px 0 128px;
@@ -335,6 +335,12 @@ body.reordering { user-select: none; -webkit-user-select: none; cursor: grabbing
 .input--cell::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 .input--cell[type="number"] { -moz-appearance: textfield; appearance: textfield; }
 .setrow__del { padding: 0; font-size: 12px; min-height: 44px; }
+
+/* RIR prompt, one row per exercise, shown in a sheet at Finish */
+.rir-row { margin-top: 16px; }
+.rir-row:first-child { margin-top: 4px; }
+.rir-row__title { font-size: 14px; font-weight: 600; margin-bottom: 6px; }
+.rir-row__buttons { display: flex; gap: 8px; }
 
 /* session history rows */
 .session-row {

--- a/src/mycoach/static/logger/app.js
+++ b/src/mycoach/static/logger/app.js
@@ -880,14 +880,18 @@
         }, 220);
     }
 
-    function finishSession(s) {
-        /* Rows appear prefilled and are stored immediately, so a tapped-then-
-           abandoned row is a set with nothing in it. It is not data — and a
-           null weight *and* null reps would poison the 1RM estimates the
-           coaching prompts read — so it is dropped rather than synced. */
-        s.exercises.forEach(function (ex) {
+    /* Rows appear prefilled and are stored immediately, so a tapped-then-
+       abandoned row is a set with nothing in it. It is not data — and a
+       null weight *and* null reps would poison the 1RM estimates the
+       coaching prompts read — so it is dropped rather than synced. */
+    function pruneEmptySets(exercises) {
+        exercises.forEach(function (ex) {
             ex.sets = ex.sets.filter(function (set) { return set.weight_kg != null || set.reps != null; });
         });
+    }
+
+    function finishSession(s) {
+        pruneEmptySets(s.exercises);
         s.end_time = new Date().toISOString();
         persistNow(s).then(function () {
             render();
@@ -979,34 +983,44 @@
     }
 
     // ── Boot ────────────────────────────────────────────────────────
-    $("sync-chip").addEventListener("click", function () { syncNow(true); });
-    window.addEventListener("online", function () { refreshChip(); syncNow(false); pullRoutine(); });
-    window.addEventListener("offline", refreshChip);
-    // A swipe-away kill does not always fire visibilitychange first.
-    window.addEventListener("pagehide", function () { flushPersist(); });
-    document.addEventListener("visibilitychange", function () {
-        // Walking back into LAN range and reopening the tab should retry
-        // without waiting for the next manual sync press.
-        if (document.visibilityState !== "visible") { flushPersist(); return; }
-        syncNow(false);
-        // iOS silently drops the lock when the tab backgrounds.
-        if (wakeWanted) acquireWakeLock();
-    });
-
-    getMeta("exercises").then(function (list) { if (list) state.exerciseCache = list; });
-    getMeta("routine").then(function (r) {
-        state.routine = r;
-        if (state.activeId === null && !document.querySelector(".sheet-backdrop")) render();
-    });
-
-    if ("serviceWorker" in navigator) {
-        navigator.serviceWorker.register("/logger/sw.js", { scope: "/logger" }).catch(function (e) {
-            console.warn("[logger] SW registration failed:", e);
+    // Guarded so this file can also be `require()`d by node:test for its
+    // pure functions (see the export guard below), which has no DOM.
+    if (typeof document !== "undefined") {
+        $("sync-chip").addEventListener("click", function () { syncNow(true); });
+        window.addEventListener("online", function () { refreshChip(); syncNow(false); pullRoutine(); });
+        window.addEventListener("offline", refreshChip);
+        // A swipe-away kill does not always fire visibilitychange first.
+        window.addEventListener("pagehide", function () { flushPersist(); });
+        document.addEventListener("visibilitychange", function () {
+            // Walking back into LAN range and reopening the tab should retry
+            // without waiting for the next manual sync press.
+            if (document.visibilityState !== "visible") { flushPersist(); return; }
+            syncNow(false);
+            // iOS silently drops the lock when the tab backgrounds.
+            if (wakeWanted) acquireWakeLock();
         });
+
+        getMeta("exercises").then(function (list) { if (list) state.exerciseCache = list; });
+        getMeta("routine").then(function (r) {
+            state.routine = r;
+            if (state.activeId === null && !document.querySelector(".sheet-backdrop")) render();
+        });
+
+        if ("serviceWorker" in navigator) {
+            navigator.serviceWorker.register("/logger/sw.js", { scope: "/logger" }).catch(function (e) {
+                console.warn("[logger] SW registration failed:", e);
+            });
+        }
+
+        render();
+        pullExercises();
+        pullRoutine();
+        syncNow(false);
     }
 
-    render();
-    pullExercises();
-    pullRoutine();
-    syncNow(false);
+    /* Dev-only: exposes pure functions to node:test. `module` is undefined in
+       the browser, so this branch never runs there. */
+    if (typeof module !== "undefined" && module.exports) {
+        module.exports = { toPayload: toPayload, repRangeLowerBound: repRangeLowerBound, numOrNull: numOrNull, pruneEmptySets: pruneEmptySets };
+    }
 })();

--- a/src/mycoach/static/logger/app.js
+++ b/src/mycoach/static/logger/app.js
@@ -164,6 +164,27 @@
         return m ? parseInt(m[1], 10) : null;
     }
 
+    /* The heaviest working (non-warmup) set in an exercise, ties going to the
+       first set reached at that weight. A bodyweight exercise with no logged
+       weight still has a top set — the first working set — since every entry
+       there is tied at "no weight". Exercises with no working sets have none. */
+    function topSetForExercise(ex) {
+        var working = ex.sets.filter(function (set) { return (set.set_type || "normal") !== "warmup"; });
+        if (!working.length) return null;
+        var top = working[0];
+        var topWeight = top.weight_kg != null ? top.weight_kg : -Infinity;
+        for (var i = 1; i < working.length; i++) {
+            var weight = working[i].weight_kg != null ? working[i].weight_kg : -Infinity;
+            if (weight > topWeight) { top = working[i]; topWeight = weight; }
+        }
+        return top;
+    }
+
+    /* rir "3+" has no exact RPE — writing null is honest, a naive 7 would be
+       false precision GymWorkoutDetail.rpe doesn't need (it already has an
+       established null-handling path for Hevy history / manual entry). */
+    var RIR_TO_RPE = { "0": 10, "1": 9, "2": 8, "3+": null };
+
     /* Flatten a stored session to the canonical WorkoutImport payload. */
     function toPayload(s) {
         var sets = [];
@@ -450,7 +471,7 @@
             setActionbar([
                 el("button", { class: "iconbtn", "aria-label": "Cancel session", onclick: function () { confirmCancel(s); } }, ["✕"]),
                 el("button", { class: "btn btn--ghost", onclick: function () { openAddExercise(s); } }, ["＋ Exercise"]),
-                el("button", { class: "btn btn--primary", style: "flex:2", onclick: function () { finishSession(s); } }, ["Finish"]),
+                el("button", { class: "btn btn--primary", style: "flex:2", onclick: function () { promptFinish(s); } }, ["Finish"]),
             ]);
         }
     }
@@ -587,7 +608,6 @@
             el("span", {}),
             el("span", { text: "kg" }),
             el("span", { text: "reps" }),
-            el("span", { text: "rpe" }),
             el("span", {}),
         ]);
     }
@@ -636,13 +656,8 @@
             { class: "input input--cell mono", type: "number", inputmode: "numeric", min: "0", placeholder: "—", "aria-label": "Reps", value: set.reps != null ? set.reps : "" },
             function (v) { set.reps = numOrNull(v, function (x) { return parseInt(x, 10); }); }
         );
-        var rpe = cell(
-            { class: "input input--cell mono", type: "number", inputmode: "decimal", step: "0.5", min: "1", max: "10", placeholder: "—", "aria-label": "RPE", value: set.rpe != null ? set.rpe : "" },
-            function (v) { set.rpe = numOrNull(v, parseFloat); }
-        );
-
         var row = el("div", { class: "setrow setrow--edit" }, [
-            badge, weight, reps, rpe,
+            badge, weight, reps,
             el("button", { class: "iconbtn setrow__del", "aria-label": "Delete set", onclick: function () { removeSet(s, ex, card, set, row); } }, ["✕"]),
         ]);
         return row;
@@ -890,6 +905,55 @@
         });
     }
 
+    /* RIR is asked once per exercise, on the top set only, at Finish — not
+       live as sets are entered, so there's nothing to re-target mid-session.
+       The overlay never blocks Finish: proceeding past it (or dismissing it)
+       leaves any unanswered exercise's rpe untouched (null, same as every
+       other set). */
+    function promptFinish(s) {
+        var tops = [];
+        s.exercises.forEach(function (ex) {
+            var set = topSetForExercise(ex);
+            if (set) tops.push({ ex: ex, set: set });
+        });
+        if (!tops.length) { finishSession(s); return; }
+        openRirSheet(s, tops);
+    }
+
+    function openRirSheet(s, tops) {
+        var rows = tops.map(function (t) { return rirRow(t.set, t.ex.title); });
+        openSheet("How many more reps could you have done?", rows.concat([
+            el("button", {
+                class: "btn btn--primary btn--block", style: "margin-top:16px",
+                onclick: function () { closeSheet(); finishSession(s); },
+            }, ["Save session"]),
+        ]));
+    }
+
+    /* Selection state lives only in this closure, not on the set: the set
+       has nowhere to put "3+ was tapped" that's distinct from "never asked"
+       (both write rpe = null), and it doesn't need one — the sheet is thrown
+       away the moment Finish completes. */
+    function rirRow(set, title) {
+        var buttons = {};
+        function select(label) {
+            set.rpe = RIR_TO_RPE[label];
+            Object.keys(buttons).forEach(function (l) {
+                buttons[l].className = "btn btn--sm " + (l === label ? "btn--primary" : "btn--ghost");
+            });
+        }
+        Object.keys(RIR_TO_RPE).forEach(function (label) {
+            buttons[label] = el("button", {
+                class: "btn btn--sm btn--ghost", style: "flex:1",
+                onclick: function () { select(label); },
+            }, [label]);
+        });
+        return el("div", { class: "rir-row" }, [
+            el("div", { class: "rir-row__title", text: title }),
+            el("div", { class: "rir-row__buttons" }, Object.keys(RIR_TO_RPE).map(function (l) { return buttons[l]; })),
+        ]);
+    }
+
     function finishSession(s) {
         pruneEmptySets(s.exercises);
         s.end_time = new Date().toISOString();
@@ -1021,6 +1085,6 @@
     /* Dev-only: exposes pure functions to node:test. `module` is undefined in
        the browser, so this branch never runs there. */
     if (typeof module !== "undefined" && module.exports) {
-        module.exports = { toPayload: toPayload, repRangeLowerBound: repRangeLowerBound, numOrNull: numOrNull, pruneEmptySets: pruneEmptySets };
+        module.exports = { toPayload: toPayload, repRangeLowerBound: repRangeLowerBound, numOrNull: numOrNull, pruneEmptySets: pruneEmptySets, topSetForExercise: topSetForExercise };
     }
 })();

--- a/src/mycoach/static/logger/app.test.js
+++ b/src/mycoach/static/logger/app.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { repRangeLowerBound, numOrNull, toPayload, pruneEmptySets } = require("./app.js");
+const { repRangeLowerBound, numOrNull, toPayload, pruneEmptySets, topSetForExercise } = require("./app.js");
 
 test("repRangeLowerBound reads the lower bound of a range like '8-10'", () => {
     assert.equal(repRangeLowerBound("8-10"), 8);
@@ -85,4 +85,54 @@ test("pruneEmptySets drops sets with neither weight nor reps", () => {
 
     assert.equal(exercises[0].sets.length, 2);
     assert.deepEqual(exercises[0].sets.map((s) => s.reps), [5, 3]);
+});
+
+test("topSetForExercise picks the heaviest working set", () => {
+    const ex = {
+        sets: [
+            { weight_kg: 80, reps: 8, set_type: "normal" },
+            { weight_kg: 100, reps: 3, set_type: "normal" },
+            { weight_kg: 90, reps: 5, set_type: "normal" },
+        ],
+    };
+    assert.equal(topSetForExercise(ex), ex.sets[1]);
+});
+
+test("topSetForExercise breaks ties in favour of the first set reached", () => {
+    const ex = {
+        sets: [
+            { weight_kg: 100, reps: 5, set_type: "normal" },
+            { weight_kg: 100, reps: 4, set_type: "normal" },
+        ],
+    };
+    assert.equal(topSetForExercise(ex), ex.sets[0]);
+});
+
+test("topSetForExercise never picks a warmup set", () => {
+    const ex = {
+        sets: [
+            { weight_kg: 120, reps: 5, set_type: "warmup" },
+            { weight_kg: 100, reps: 5, set_type: "normal" },
+        ],
+    };
+    assert.equal(topSetForExercise(ex), ex.sets[1]);
+});
+
+test("topSetForExercise returns null when every set is a warmup", () => {
+    const ex = { sets: [{ weight_kg: 60, reps: 8, set_type: "warmup" }] };
+    assert.equal(topSetForExercise(ex), null);
+});
+
+test("topSetForExercise returns null with no sets at all", () => {
+    assert.equal(topSetForExercise({ sets: [] }), null);
+});
+
+test("topSetForExercise treats a bodyweight exercise's first working set as top", () => {
+    const ex = {
+        sets: [
+            { weight_kg: null, reps: 12, set_type: "normal" },
+            { weight_kg: null, reps: 10, set_type: "normal" },
+        ],
+    };
+    assert.equal(topSetForExercise(ex), ex.sets[0]);
 });

--- a/src/mycoach/static/logger/app.test.js
+++ b/src/mycoach/static/logger/app.test.js
@@ -1,0 +1,88 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { repRangeLowerBound, numOrNull, toPayload, pruneEmptySets } = require("./app.js");
+
+test("repRangeLowerBound reads the lower bound of a range like '8-10'", () => {
+    assert.equal(repRangeLowerBound("8-10"), 8);
+});
+
+test("repRangeLowerBound reads a bare number as its own lower bound", () => {
+    assert.equal(repRangeLowerBound("12"), 12);
+});
+
+test("repRangeLowerBound returns null for empty or unparseable input", () => {
+    assert.equal(repRangeLowerBound(""), null);
+    assert.equal(repRangeLowerBound(null), null);
+    assert.equal(repRangeLowerBound("failure"), null);
+});
+
+test("numOrNull parses a numeric string with the given parser", () => {
+    assert.equal(numOrNull("82.5", parseFloat), 82.5);
+});
+
+test("numOrNull treats an empty string as null, not NaN", () => {
+    assert.equal(numOrNull("", parseFloat), null);
+});
+
+test("numOrNull treats unparseable input as null", () => {
+    assert.equal(numOrNull("abc", parseFloat), null);
+});
+
+test("toPayload flattens a session's exercises into one flat sets array", () => {
+    const session = {
+        id: "s1",
+        title: "Push day",
+        start_time: "2026-09-01T10:00:00Z",
+        end_time: "2026-09-01T11:00:00Z",
+        notes: null,
+        exercises: [
+            {
+                title: "Bench Press",
+                notes: null,
+                superset_group: null,
+                sets: [
+                    { weight_kg: 80, reps: 5, rpe: 8, set_type: "normal", prescribed_weight_kg: 80, prescribed_reps: 5 },
+                    { weight_kg: 82.5, reps: 4, rpe: null, set_type: "normal" },
+                ],
+            },
+        ],
+    };
+
+    const payload = toPayload(session);
+
+    assert.equal(payload.external_id, "s1");
+    assert.equal(payload.sport, "gym");
+    assert.equal(payload.sets.length, 2);
+    assert.deepEqual(payload.sets[0], {
+        exercise_title: "Bench Press",
+        exercise_notes: null,
+        set_index: 1,
+        set_type: "normal",
+        superset_id: null,
+        weight_kg: 80,
+        reps: 5,
+        rpe: 8,
+        prescribed_weight_kg: 80,
+        prescribed_reps: 5,
+    });
+    assert.equal(payload.sets[1].set_index, 2);
+    assert.equal(payload.sets[1].prescribed_weight_kg, null);
+});
+
+test("pruneEmptySets drops sets with neither weight nor reps", () => {
+    const exercises = [
+        {
+            title: "Squat",
+            sets: [
+                { weight_kg: 100, reps: 5 },
+                { weight_kg: null, reps: null },
+                { weight_kg: null, reps: 3 },
+            ],
+        },
+    ];
+
+    pruneEmptySets(exercises);
+
+    assert.equal(exercises[0].sets.length, 2);
+    assert.deepEqual(exercises[0].sets.map((s) => s.reps), [5, 3]);
+});


### PR DESCRIPTION
## Summary
- No JS test harness existed for `app.js` (no `package.json`, no runner). Decided via grilling on #73 to test pure functions only, using Node's built-in `node:test` (zero dependencies — the map's "no JS dependencies" preference is about what ships, not dev tooling).
- `app.js` stays a single classic-script IIFE (no build step). A conditional `module.exports` guard at the end of the IIFE exposes `toPayload`, `repRangeLowerBound`, `numOrNull`, and a newly-extracted `pruneEmptySets` (lifted out of `finishSession`'s inline filter) for `require()`. `module` is undefined in the browser, so it's dead code there.
- The `// Boot` block (event listeners, initial render/sync/service-worker registration) is guarded behind `typeof document !== "undefined"` so `require("./app.js")` doesn't crash under Node — it only runs in the browser, unchanged behavior there.
- DOM/state testing (re-render, drag-reorder, the deferred-write queue from #49) is explicitly deferred — out of scope here, to be picked up once `app.js` has real module seams worth testing against.

Resolves #73.

## Test plan
- [x] `node --test src/mycoach/static/logger/app.test.js` — 8/8 pass (ran via `docker run node:20-slim`, no Node on the dev host)
- [x] Diffed against `origin/main` to confirm the Boot-guard change is behavior-preserving in the browser (unconditional calls just moved inside a `typeof document !== "undefined"` check that's always true there)
- [ ] Manual: load `/logger` in a browser and confirm sync chip, service worker registration, and initial render still fire (not verified on a device in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)