### PR TITLE
RIR prompt on the top set, replacing per-set RPE

### DIFF
--- a/src/mycoach/static/logger/app.css
+++ b/src/mycoach/static/logger/app.css
@@ -292,7 +292,7 @@ body.reordering { user-select: none; -webkit-user-select: none; cursor: grabbing
 
 /* editable set rows — the row is the input, there is no save step */
 .setrow--edit {
-    grid-template-columns: 34px 1fr 1fr 58px 28px;
+    grid-template-columns: 34px 1fr 1fr 28px;
     padding: 5px 0;
     /* clears the fixed action bar when a focused row is scrolled into view */
     scroll-margin: 96px 0 128px;
@@ -335,6 +335,12 @@ body.reordering { user-select: none; -webkit-user-select: none; cursor: grabbing
 .input--cell::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 .input--cell[type="number"] { -moz-appearance: textfield; appearance: textfield; }
 .setrow__del { padding: 0; font-size: 12px; min-height: 44px; }
+
+/* RIR prompt, one row per exercise, shown in a sheet at Finish */
+.rir-row { margin-top: 16px; }
+.rir-row:first-child { margin-top: 4px; }
+.rir-row__title { font-size: 14px; font-weight: 600; margin-bottom: 6px; }
+.rir-row__buttons { display: flex; gap: 8px; }
 
 /* session history rows */
 .session-row {

--- a/src/mycoach/static/logger/app.js
+++ b/src/mycoach/static/logger/app.js
@@ -164,6 +164,27 @@
         return m ? parseInt(m[1], 10) : null;
     }
 
+    /* The heaviest working (non-warmup) set in an exercise, ties going to the
+       first set reached at that weight. A bodyweight exercise with no logged
+       weight still has a top set — the first working set — since every entry
+       there is tied at "no weight". Exercises with no working sets have none. */
+    function topSetForExercise(ex) {
+        var working = ex.sets.filter(function (set) { return (set.set_type || "normal") !== "warmup"; });
+        if (!working.length) return null;
+        var top = working[0];
+        var topWeight = top.weight_kg != null ? top.weight_kg : -Infinity;
+        for (var i = 1; i < working.length; i++) {
+            var weight = working[i].weight_kg != null ? working[i].weight_kg : -Infinity;
+            if (weight > topWeight) { top = working[i]; topWeight = weight; }
+        }
+        return top;
+    }
+
+    /* rir "3+" has no exact RPE — writing null is honest, a naive 7 would be
+       false precision GymWorkoutDetail.rpe doesn't need (it already has an
+       established null-handling path for Hevy history / manual entry). */
+    var RIR_TO_RPE = { "0": 10, "1": 9, "2": 8, "3+": null };
+
     /* Flatten a stored session to the canonical WorkoutImport payload. */
     function toPayload(s) {
         var sets = [];
@@ -450,7 +471,7 @@
             setActionbar([
                 el("button", { class: "iconbtn", "aria-label": "Cancel session", onclick: function () { confirmCancel(s); } }, ["✕"]),
                 el("button", { class: "btn btn--ghost", onclick: function () { openAddExercise(s); } }, ["＋ Exercise"]),
-                el("button", { class: "btn btn--primary", style: "flex:2", onclick: function () { finishSession(s); } }, ["Finish"]),
+                el("button", { class: "btn btn--primary", style: "flex:2", onclick: function () { promptFinish(s); } }, ["Finish"]),
             ]);
         }
     }
@@ -587,7 +608,6 @@
             el("span", {}),
             el("span", { text: "kg" }),
             el("span", { text: "reps" }),
-            el("span", { text: "rpe" }),
             el("span", {}),
         ]);
     }
@@ -636,13 +656,8 @@
             { class: "input input--cell mono", type: "number", inputmode: "numeric", min: "0", placeholder: "—", "aria-label": "Reps", value: set.reps != null ? set.reps : "" },
             function (v) { set.reps = numOrNull(v, function (x) { return parseInt(x, 10); }); }
         );
-        var rpe = cell(
-            { class: "input input--cell mono", type: "number", inputmode: "decimal", step: "0.5", min: "1", max: "10", placeholder: "—", "aria-label": "RPE", value: set.rpe != null ? set.rpe : "" },
-            function (v) { set.rpe = numOrNull(v, parseFloat); }
-        );
-
         var row = el("div", { class: "setrow setrow--edit" }, [
-            badge, weight, reps, rpe,
+            badge, weight, reps,
             el("button", { class: "iconbtn setrow__del", "aria-label": "Delete set", onclick: function () { removeSet(s, ex, card, set, row); } }, ["✕"]),
         ]);
         return row;
@@ -890,6 +905,55 @@
         });
     }
 
+    /* RIR is asked once per exercise, on the top set only, at Finish — not
+       live as sets are entered, so there's nothing to re-target mid-session.
+       The overlay never blocks Finish: proceeding past it (or dismissing it)
+       leaves any unanswered exercise's rpe untouched (null, same as every
+       other set). */
+    function promptFinish(s) {
+        var tops = [];
+        s.exercises.forEach(function (ex) {
+            var set = topSetForExercise(ex);
+            if (set) tops.push({ ex: ex, set: set });
+        });
+        if (!tops.length) { finishSession(s); return; }
+        openRirSheet(s, tops);
+    }
+
+    function openRirSheet(s, tops) {
+        var rows = tops.map(function (t) { return rirRow(t.set, t.ex.title); });
+        openSheet("How many more reps could you have done?", rows.concat([
+            el("button", {
+                class: "btn btn--primary btn--block", style: "margin-top:16px",
+                onclick: function () { closeSheet(); finishSession(s); },
+            }, ["Save session"]),
+        ]));
+    }
+
+    /* Selection state lives only in this closure, not on the set: the set
+       has nowhere to put "3+ was tapped" that's distinct from "never asked"
+       (both write rpe = null), and it doesn't need one — the sheet is thrown
+       away the moment Finish completes. */
+    function rirRow(set, title) {
+        var buttons = {};
+        function select(label) {
+            set.rpe = RIR_TO_RPE[label];
+            Object.keys(buttons).forEach(function (l) {
+                buttons[l].className = "btn btn--sm " + (l === label ? "btn--primary" : "btn--ghost");
+            });
+        }
+        Object.keys(RIR_TO_RPE).forEach(function (label) {
+            buttons[label] = el("button", {
+                class: "btn btn--sm btn--ghost", style: "flex:1",
+                onclick: function () { select(label); },
+            }, [label]);
+        });
+        return el("div", { class: "rir-row" }, [
+            el("div", { class: "rir-row__title", text: title }),
+            el("div", { class: "rir-row__buttons" }, Object.keys(RIR_TO_RPE).map(function (l) { return buttons[l]; })),
+        ]);
+    }
+
     function finishSession(s) {
         pruneEmptySets(s.exercises);
         s.end_time = new Date().toISOString();
@@ -1021,6 +1085,6 @@
     /* Dev-only: exposes pure functions to node:test. `module` is undefined in
        the browser, so this branch never runs there. */
     if (typeof module !== "undefined" && module.exports) {
-        module.exports = { toPayload: toPayload, repRangeLowerBound: repRangeLowerBound, numOrNull: numOrNull, pruneEmptySets: pruneEmptySets };
+        module.exports = { toPayload: toPayload, repRangeLowerBound: repRangeLowerBound, numOrNull: numOrNull, pruneEmptySets: pruneEmptySets, topSetForExercise: topSetForExercise };
     }
 })();

--- a/src/mycoach/static/logger/app.test.js
+++ b/src/mycoach/static/logger/app.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { repRangeLowerBound, numOrNull, toPayload, pruneEmptySets } = require("./app.js");
+const { repRangeLowerBound, numOrNull, toPayload, pruneEmptySets, topSetForExercise } = require("./app.js");
 
 test("repRangeLowerBound reads the lower bound of a range like '8-10'", () => {
     assert.equal(repRangeLowerBound("8-10"), 8);
@@ -85,4 +85,54 @@ test("pruneEmptySets drops sets with neither weight nor reps", () => {
 
     assert.equal(exercises[0].sets.length, 2);
     assert.deepEqual(exercises[0].sets.map((s) => s.reps), [5, 3]);
+});
+
+test("topSetForExercise picks the heaviest working set", () => {
+    const ex = {
+        sets: [
+            { weight_kg: 80, reps: 8, set_type: "normal" },
+            { weight_kg: 100, reps: 3, set_type: "normal" },
+            { weight_kg: 90, reps: 5, set_type: "normal" },
+        ],
+    };
+    assert.equal(topSetForExercise(ex), ex.sets[1]);
+});
+
+test("topSetForExercise breaks ties in favour of the first set reached", () => {
+    const ex = {
+        sets: [
+            { weight_kg: 100, reps: 5, set_type: "normal" },
+            { weight_kg: 100, reps: 4, set_type: "normal" },
+        ],
+    };
+    assert.equal(topSetForExercise(ex), ex.sets[0]);
+});
+
+test("topSetForExercise never picks a warmup set", () => {
+    const ex = {
+        sets: [
+            { weight_kg: 120, reps: 5, set_type: "warmup" },
+            { weight_kg: 100, reps: 5, set_type: "normal" },
+        ],
+    };
+    assert.equal(topSetForExercise(ex), ex.sets[1]);
+});
+
+test("topSetForExercise returns null when every set is a warmup", () => {
+    const ex = { sets: [{ weight_kg: 60, reps: 8, set_type: "warmup" }] };
+    assert.equal(topSetForExercise(ex), null);
+});
+
+test("topSetForExercise returns null with no sets at all", () => {
+    assert.equal(topSetForExercise({ sets: [] }), null);
+});
+
+test("topSetForExercise treats a bodyweight exercise's first working set as top", () => {
+    const ex = {
+        sets: [
+            { weight_kg: null, reps: 12, set_type: "normal" },
+            { weight_kg: null, reps: 10, set_type: "normal" },
+        ],
+    };
+    assert.equal(topSetForExercise(ex), ex.sets[0]);
 });


### PR DESCRIPTION
## Summary
- Removes the free-text RPE input from every set row.
- Adds an optional overlay at Finish: one RIR prompt (0 / 1 / 2 / 3+) per exercise, for its top set (heaviest working set; ties go to the first reached; warmups never qualify).
- Converts `rir -> rpe = 10 - rir`; `3+` writes `null` rather than a false-precision 7. The overlay never blocks Finish — unanswered exercises leave `rpe` null, same as before.
- `rpe` stays the canonical `GymWorkoutDetail` column and is still accepted on import untouched, for Hevy history / manual entry.

Stacked on `feat/73-logger-js-testing` (#79), which hasn't merged yet — the new `topSetForExercise` pure function is covered under the `node:test` infra that PR adds.

Part of #44, resolves #53.

## Test plan
- [x] `node --test app.js`/`app.test.js` — 14/14 pass, including 6 new cases for `topSetForExercise` (heaviest wins, ties go first, warmups excluded, all-warmup/no-sets → null, bodyweight exercise's first set is top).
- [ ] Manual: log a session on a device, confirm the Finish overlay shows one RIR row per exercise with a top set, tapping 3+ writes null rpe, dismissing/Finishing without answering leaves rpe null.